### PR TITLE
Watch did stop on Test Cluster #32

### DIFF
--- a/java/common/org.eclipse.theia.cloud.common/.classpath
+++ b/java/common/org.eclipse.theia.cloud.common/.classpath
@@ -6,20 +6,9 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
+			<attribute name="module" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
@@ -30,9 +19,9 @@
 	</classpathentry>
 	<classpathentry kind="src" path="target/generated-sources/annotations">
 		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="m2e-apt" value="true"/>
 		</attributes>
 	</classpathentry>
@@ -43,17 +32,17 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path=".apt_generated_tests">
 		<attributes>
-			<attribute name="optional" value="true"/>
 			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="m2e-apt" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/java/operator/org.eclipse.theia.cloud.operator/log4j2.xml
+++ b/java/operator/org.eclipse.theia.cloud.operator/log4j2.xml
@@ -11,6 +11,10 @@
 			additivity="false">
 			<AppenderRef ref="Console" />
 		</Logger>
+		<Logger name="org.eclipse.theia.cloud.operator.KillAfterRunnable" level="warn"
+			additivity="false">
+			<AppenderRef ref="Console" />
+		</Logger>
 		<Logger name="org.eclipse.theia.cloud.operator" level="trace"
 			additivity="false">
 			<AppenderRef ref="Console" />

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/SpecWatch.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/SpecWatch.java
@@ -90,4 +90,16 @@ final class SpecWatch<S extends CustomResource<?, ?>> implements Watcher<S> {
 		cause);
 	System.exit(-1);
     }
+
+    @Override
+    public void onClose() {
+	LOGGER.info(formatLogMessage(correlationIdPrefix, resourceName + " watch closed"));
+	Watcher.super.onClose();
+    }
+
+    @Override
+    public boolean reconnecting() {
+	LOGGER.info(formatLogMessage(correlationIdPrefix, resourceName + " reconnecting"));
+	return Watcher.super.reconnecting();
+    }
 }


### PR DESCRIPTION
* add more logging to spec watch
* adjust log config to reduce spam caused by kill runnable
* fix classpath (remove non existing directories)

Besides these changes, which will mainly improve logging, we will also update the cluster to use kubernetes 1.22 as the root cause might be a kubernetes bug

Closes #32 for now, since we have to see whether it appears again with kubernetes 1.22