### PR TITLE
Removed . from chart name

### DIFF
--- a/helm/theia.cloud/Chart.yaml
+++ b/helm/theia.cloud/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: theia.cloud
-description: A Helm chart for Theia.Cloud
+name: theiacloud
+description: A Helm chart for Theia Cloud
 
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
Periods in the chart name unfortunately cause issues when using theia-cloud as a subchart, and are also against the [helm chart naming conventions ](https://helm.sh/docs/chart_best_practices/conventions/). Dashes can also cause issues (they are not allowed in values, there is a workaround but it's easier to just avoid them) so I would suggest just concatenation of the two words as a name.

I have to keep this changed in the downstream so it would be very convenient for me to have this changed in the main repository to avoid conflicts.
