### PR TITLE
Fix generation of names for k8s resources

### DIFF
--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
@@ -15,11 +15,47 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.common.util;
 
+import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
+import org.eclipse.theia.cloud.common.k8s.resource.Session;
+import org.eclipse.theia.cloud.common.k8s.resource.Workspace;
+
 public final class NamingUtil {
     public static final int VALID_NAME_LIMIT = 62;
 
     private NamingUtil() {
 	// utility
+    }
+
+    public static String createName(AppDefinition appDefinition, int instance, String suffix) {
+	return createName(instance + "-" + appDefinition.getMetadata().getUid(), suffix,
+		getAdditionalInformation(appDefinition));
+    }
+
+    public static String createName(Session session, String suffix) {
+	return createName(session.getMetadata().getUid(), suffix, getAdditionalInformation(session));
+    }
+
+    public static String createName(Workspace workspace, String suffix) {
+	return createName(workspace.getMetadata().getUid(), suffix, getAdditionalInformation(workspace));
+    }
+
+    private static String createName(String prefix, String suffix, String additionalInformation) {
+	return asValidName(prefix + "-" + suffix + "-" + additionalInformation);
+    }
+
+    private static String getAdditionalInformation(AppDefinition appDefinition) {
+	return appDefinition.getSpec().getName();
+    }
+
+    private static String getAdditionalInformation(Session session) {
+	String workspace = (session.getSpec().getWorkspace() == null || session.getSpec().getWorkspace().isBlank())
+		? "none"
+		: session.getSpec().getWorkspace();
+	return session.getSpec().getUser() + "-" + workspace + "-" + session.getSpec().getAppDefinition();
+    }
+
+    private static String getAdditionalInformation(Workspace workspace) {
+	return workspace.getSpec().getName();
     }
 
     /**

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/WorkspaceUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/WorkspaceUtil.java
@@ -19,9 +19,11 @@ import static org.eclipse.theia.cloud.common.util.NamingUtil.asValidName;
 
 import java.time.Instant;
 
+import org.eclipse.theia.cloud.common.k8s.resource.Workspace;
+
 public final class WorkspaceUtil {
     private static final String SESSION_SUFFIX = "-session";
-    private static final String STORAGE_SUFFIX = "-pvc";
+    private static final String STORAGE_SUFFIX = "pvc";
     private static final String WORKSPACE_PREFIX = "ws-";
     private static final int WORKSPACE_NAME_LIMIT = NamingUtil.VALID_NAME_LIMIT - SESSION_SUFFIX.length();
 
@@ -42,27 +44,8 @@ public final class WorkspaceUtil {
 	return getSessionName(generateWorkspaceName(user, getWorkspaceDescription(appDefinitionName)));
     }
 
-    public static String getStorageName(String workspaceName) {
-	return workspaceName + STORAGE_SUFFIX;
-    }
-
-    public static String getWorkspaceNameFromSession(String sessionName) {
-	return sessionName.endsWith(SESSION_SUFFIX)
-		? sessionName.substring(0, sessionName.length() - SESSION_SUFFIX.length())
-		: sessionName;
-    }
-
-    public static String getWorkspaceNameFromStorage(String pvcName) {
-	return pvcName.endsWith(STORAGE_SUFFIX) ? pvcName.substring(0, pvcName.length() - STORAGE_SUFFIX.length())
-		: pvcName;
-    }
-
-    public static String getStorageNameFromSession(String sessionName) {
-	return getStorageName(getWorkspaceNameFromSession(sessionName));
-    }
-
-    public static String getSessionNameFromStorage(String sessionName) {
-	return getSessionName(getWorkspaceNameFromSession(sessionName));
+    public static String getStorageName(Workspace workspace) {
+	return NamingUtil.createName(workspace, STORAGE_SUFFIX);
     }
 
     public static String generateWorkspaceLabel(String user, String appDefinitionName) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazyWorkspaceHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazyWorkspaceHandler.java
@@ -40,7 +40,7 @@ public class LazyWorkspaceHandler implements WorkspaceHandler {
     public boolean workspaceAdded(Workspace workspace, String correlationId) {
 	LOGGER.info(formatLogMessage(correlationId, "Handling " + workspace.getSpec()));
 
-	String storageName = WorkspaceUtil.getStorageName(workspace.getSpec().getName());
+	String storageName = WorkspaceUtil.getStorageName(workspace);
 	if (!client.persistentVolumes().has(storageName)) {
 	    LOGGER.trace(formatLogMessage(correlationId, "Creating new persistent volume named " + storageName));
 	    persistentVolumeHandler.createAndApplyPersistentVolume(correlationId, workspace);
@@ -63,7 +63,7 @@ public class LazyWorkspaceHandler implements WorkspaceHandler {
 	String sessionName = WorkspaceUtil.getSessionName(workspace.getSpec().getName());
 	client.sessions().delete(correlationId, sessionName);
 
-	String storageName = WorkspaceUtil.getStorageName(workspace.getSpec().getName());
+	String storageName = WorkspaceUtil.getStorageName(workspace);
 	client.persistentVolumeClaims().delete(correlationId, storageName);
 	client.persistentVolumes().delete(correlationId, storageName);
 	return true;

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/K8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/K8sUtil.java
@@ -30,6 +30,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.resource.ResourceEdit;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
@@ -39,6 +41,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.internal.SerializationUtils;
 
 public final class K8sUtil {
 
@@ -162,7 +165,13 @@ public final class K8sUtil {
 	    ResourceEdit.<T>updateOwnerReference(ownerReferenceIndex, ownerAPIVersion, ownerKind, ownerName, ownerUid,
 		    correlationId).andThen(additionalModification).accept(newItem);
 
-	    LOGGER.trace(formatLogMessage(correlationId, "Creating new " + typeName));
+	    String resultingYaml;
+	    try {
+		resultingYaml = SerializationUtils.dumpAsYaml(newItem);
+	    } catch (JsonProcessingException e) {
+		resultingYaml = "Serializing " + typeName + " to Yaml failed.";
+	    }
+	    LOGGER.trace(formatLogMessage(correlationId, "Creating new " + typeName + ":\n" + resultingYaml));
 	    items.create(newItem);
 	    LOGGER.info(formatLogMessage(correlationId, "Created a new " + typeName));
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudConfigMapUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudConfigMapUtil.java
@@ -17,7 +17,6 @@
 package org.eclipse.theia.cloud.operator.handler.util;
 
 import static org.eclipse.theia.cloud.common.util.LogMessageUtil.formatLogMessage;
-import static org.eclipse.theia.cloud.common.util.NamingUtil.asValidName;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.Session;
+import org.eclipse.theia.cloud.common.util.NamingUtil;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 
@@ -35,48 +35,30 @@ public final class TheiaCloudConfigMapUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(TheiaCloudConfigMapUtil.class);
 
-    public static final String CONFIGMAP_PROXY_NAME = "-config-";
-    public static final String CONFIGMAP_EMAIL_NAME = "-emailconfig-";
+    public static final String CONFIGMAP_PROXY_NAME = "config";
+    public static final String CONFIGMAP_EMAIL_NAME = "emailconfig";
 
     private TheiaCloudConfigMapUtil() {
     }
 
     public static String getProxyConfigName(AppDefinition appDefinition, int instance) {
-	return asValidName(getProxyConfigNamePrefix(appDefinition) + instance);
+	return NamingUtil.createName(appDefinition, instance, CONFIGMAP_PROXY_NAME);
     }
 
     public static String getProxyConfigName(Session session) {
-	return asValidName(getProxyConfigNamePrefix(session) + session.getMetadata().getUid());
+	return NamingUtil.createName(session, CONFIGMAP_PROXY_NAME);
     }
 
     public static String getEmailConfigName(AppDefinition appDefinition, int instance) {
-	return asValidName(getEmailConfigNamePrefix(appDefinition) + instance);
+	return NamingUtil.createName(appDefinition, instance, CONFIGMAP_EMAIL_NAME);
     }
 
     public static String getEmailConfigName(Session session) {
-	return asValidName(getEmailConfigNamePrefix(session) + session.getMetadata().getUid());
-    }
-
-    private static String getProxyConfigNamePrefix(AppDefinition appDefinition) {
-	return appDefinition.getSpec().getName() + CONFIGMAP_PROXY_NAME;
-    }
-
-    private static String getProxyConfigNamePrefix(Session session) {
-	return session.getSpec().getName() + CONFIGMAP_PROXY_NAME;
-    }
-
-    private static String getEmailConfigNamePrefix(AppDefinition appDefinition) {
-	return appDefinition.getSpec().getName() + CONFIGMAP_EMAIL_NAME;
-    }
-
-    public static String getEmailConfigNamePrefix(Session session) {
-	return session.getSpec().getName() + CONFIGMAP_EMAIL_NAME;
+	return NamingUtil.createName(session, CONFIGMAP_EMAIL_NAME);
     }
 
     public static Integer getProxyId(String correlationId, AppDefinition appDefinition, ConfigMap item) {
-	int namePrefixLength = getProxyConfigNamePrefix(appDefinition).length();
-	String name = item.getMetadata().getName();
-	String instance = name.substring(namePrefixLength);
+	String instance = TheiaCloudK8sUtil.extractIdFromName(item.getMetadata());
 	try {
 	    return Integer.valueOf(instance);
 	} catch (NumberFormatException e) {
@@ -86,9 +68,7 @@ public final class TheiaCloudConfigMapUtil {
     }
 
     public static Integer getEmailId(String correlationId, AppDefinition appDefinition, ConfigMap item) {
-	int namePrefixLength = getEmailConfigNamePrefix(appDefinition).length();
-	String name = item.getMetadata().getName();
-	String instance = name.substring(namePrefixLength);
+	String instance = TheiaCloudK8sUtil.extractIdFromName(item.getMetadata());
 	try {
 	    return Integer.valueOf(instance);
 	} catch (NumberFormatException e) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudDeploymentUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudDeploymentUtil.java
@@ -17,7 +17,6 @@
 package org.eclipse.theia.cloud.operator.handler.util;
 
 import static org.eclipse.theia.cloud.common.util.LogMessageUtil.formatLogMessage;
-import static org.eclipse.theia.cloud.common.util.NamingUtil.asValidName;
 
 import java.util.List;
 import java.util.Set;
@@ -26,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.Session;
+import org.eclipse.theia.cloud.common.util.NamingUtil;
 import org.eclipse.theia.cloud.operator.handler.IngressPathProvider;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -34,7 +34,7 @@ public final class TheiaCloudDeploymentUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(TheiaCloudDeploymentUtil.class);
 
-    public static final String DEPLOYMENT_NAME = "-deployment-";
+    public static final String DEPLOYMENT_NAME = "deployment";
 
     private TheiaCloudDeploymentUtil() {
     }
@@ -44,26 +44,16 @@ public final class TheiaCloudDeploymentUtil {
 		+ "/";
     }
 
-    private static String getDeploymentNamePrefix(AppDefinition appDefinition) {
-	return appDefinition.getSpec().getName() + DEPLOYMENT_NAME;
-    }
-
-    private static String getDeploymentNamePrefix(Session session) {
-	return session.getSpec().getName() + DEPLOYMENT_NAME;
-    }
-
     public static String getDeploymentName(AppDefinition appDefinition, int instance) {
-	return asValidName(getDeploymentNamePrefix(appDefinition) + instance);
+	return NamingUtil.createName(appDefinition, instance, DEPLOYMENT_NAME);
     }
 
     public static String getDeploymentName(Session session) {
-	return asValidName(getDeploymentNamePrefix(session) + session.getMetadata().getUid());
+	return NamingUtil.createName(session, DEPLOYMENT_NAME);
     }
 
     public static Integer getId(String correlationId, AppDefinition appDefinition, Deployment deployment) {
-	int namePrefixLength = getDeploymentNamePrefix(appDefinition).length();
-	String name = deployment.getMetadata().getName();
-	String instance = name.substring(namePrefixLength);
+	String instance = TheiaCloudK8sUtil.extractIdFromName(deployment.getMetadata());
 	try {
 	    return Integer.valueOf(instance);
 	} catch (NumberFormatException e) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudHandlerUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudHandlerUtil.java
@@ -20,7 +20,6 @@ import static org.eclipse.theia.cloud.common.util.LogMessageUtil.formatLogMessag
 import static org.eclipse.theia.cloud.common.util.NamingUtil.asValidName;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -31,15 +30,9 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.Session;
 import org.eclipse.theia.cloud.common.k8s.resource.SessionSpec;
-import org.eclipse.theia.cloud.common.k8s.resource.Workspace;
-import org.eclipse.theia.cloud.common.k8s.resource.WorkspaceSpecResourceList;
-import org.eclipse.theia.cloud.common.util.WorkspaceUtil;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 
 public final class TheiaCloudHandlerUtil {
 
@@ -69,14 +62,6 @@ public final class TheiaCloudHandlerUtil {
 
     public static String getAppSelector(Session session) {
 	return asValidName(session.getSpec().getName() + "-" + session.getMetadata().getUid());
-    }
-
-    public static Optional<Workspace> getWorkspaceForSession(NamespacedKubernetesClient client, String namespace,
-	    String sessionName) {
-	String workspaceName = WorkspaceUtil.getWorkspaceNameFromSession(sessionName);
-	NonNamespaceOperation<Workspace, WorkspaceSpecResourceList, Resource<Workspace>> workspaces = client
-		.resources(Workspace.class, WorkspaceSpecResourceList.class).inNamespace(namespace);
-	return Optional.ofNullable(workspaces.withName(workspaceName).get());
     }
 
     public static <T extends HasMetadata> T addOwnerReferenceToItem(String correlationId, String sessionResourceName,

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
@@ -25,6 +25,7 @@ import org.eclipse.theia.cloud.common.k8s.resource.Session;
 import org.eclipse.theia.cloud.common.k8s.resource.SessionSpec;
 import org.eclipse.theia.cloud.common.k8s.resource.SessionSpecResourceList;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 
 public final class TheiaCloudK8sUtil {
@@ -54,6 +55,13 @@ public final class TheiaCloudK8sUtil {
 		})//
 		.count();
 	return currentInstances > appDefinitionSpec.getMaxInstances();
+    }
+
+    public static String extractIdFromName(ObjectMeta metadata) {
+	String name = metadata.getName();
+	String[] split = name.split("-");
+	String instance = split.length == 0 ? "" : split[0];
+	return instance;
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudPersistentVolumeUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudPersistentVolumeUtil.java
@@ -20,7 +20,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.eclipse.theia.cloud.common.k8s.resource.AppDefinitionSpec;
-import org.eclipse.theia.cloud.common.k8s.resource.Session;
 import org.eclipse.theia.cloud.common.k8s.resource.Workspace;
 import org.eclipse.theia.cloud.common.util.WorkspaceUtil;
 
@@ -46,13 +45,9 @@ public final class TheiaCloudPersistentVolumeUtil {
 	return mountPath;
     }
 
-    public static String getPersistentVolumeName(Session session) {
-	return WorkspaceUtil.getStorageNameFromSession(session.getSpec().getName());
-    }
-
     public static Map<String, String> getPersistentVolumeReplacements(String namespace, Workspace workspace) {
 	Map<String, String> replacements = new LinkedHashMap<String, String>();
-	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace.getSpec().getName()));
+	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace));
 	replacements.put(TheiaCloudHandlerUtil.PLACEHOLDER_NAMESPACE, namespace);
 	replacements.put(PLACEHOLDER_LABEL_WORKSPACE_NAME, workspace.getSpec().getName());
 	return replacements;
@@ -60,7 +55,7 @@ public final class TheiaCloudPersistentVolumeUtil {
 
     public static Map<String, String> getPersistentVolumeClaimReplacements(String namespace, Workspace workspace) {
 	Map<String, String> replacements = new LinkedHashMap<String, String>();
-	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace.getSpec().getName()));
+	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace));
 	replacements.put(TheiaCloudHandlerUtil.PLACEHOLDER_NAMESPACE, namespace);
 	replacements.put(PLACEHOLDER_LABEL_WORKSPACE_NAME, workspace.getSpec().getName());
 	return replacements;

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudServiceUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudServiceUtil.java
@@ -17,7 +17,6 @@
 package org.eclipse.theia.cloud.operator.handler.util;
 
 import static org.eclipse.theia.cloud.common.util.LogMessageUtil.formatLogMessage;
-import static org.eclipse.theia.cloud.common.util.NamingUtil.asValidName;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -29,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.Session;
+import org.eclipse.theia.cloud.common.util.NamingUtil;
 
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Service;
@@ -37,7 +37,7 @@ public final class TheiaCloudServiceUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(TheiaCloudServiceUtil.class);
 
-    public static final String SERVICE_NAME = "-service-";
+    public static final String SERVICE_NAME = "service";
 
     public static final String PLACEHOLDER_SERVICENAME = "placeholder-servicename";
 
@@ -45,25 +45,15 @@ public final class TheiaCloudServiceUtil {
     }
 
     public static String getServiceName(AppDefinition appDefinition, int instance) {
-	return asValidName(getServiceNamePrefix(appDefinition) + instance);
+	return NamingUtil.createName(appDefinition, instance, SERVICE_NAME);
     }
 
     public static String getServiceName(Session session) {
-	return asValidName(getServiceNamePrefix(session) + session.getMetadata().getUid());
-    }
-
-    private static String getServiceNamePrefix(AppDefinition appDefinition) {
-	return appDefinition.getSpec().getName() + SERVICE_NAME;
-    }
-
-    private static String getServiceNamePrefix(Session session) {
-	return session.getSpec().getName() + SERVICE_NAME;
+	return NamingUtil.createName(session, SERVICE_NAME);
     }
 
     public static Integer getId(String correlationId, AppDefinition appDefinition, Service service) {
-	int namePrefixLength = getServiceNamePrefix(appDefinition).length();
-	String name = service.getMetadata().getName();
-	String instance = name.substring(namePrefixLength);
+	String instance = TheiaCloudK8sUtil.extractIdFromName(service.getMetadata());
 	try {
 	    return Integer.valueOf(instance);
 	} catch (NumberFormatException e) {


### PR DESCRIPTION
* name pattern will be (InstanceId-)CustomResourceUID-Suffix-AdditionalInformation
* If string gets to long we cut from the end. This should only affect additional information which is only used to make the resource purpose easier to grasp on first sight.

Fixes #71