### PR TITLE
Make Quarkus more configurable

### DIFF
--- a/dockerfiles/service/Dockerfile
+++ b/dockerfiles/service/Dockerfile
@@ -13,5 +13,8 @@ FROM openjdk:11-jre-slim-buster
 WORKDIR /service
 COPY --from=builder /service/service/org.eclipse.theia.cloud.service/target/service-0.7.0-SNAPSHOT-runner.jar .
 ENV APPID default-app-id
-ENTRYPOINT java -Dtheia.cloud.app.id=${APPID} -jar ./service-0.7.0-SNAPSHOT-runner.jar
+ENV SERVICE_PORT 8081
+ENTRYPOINT java -Dtheia.cloud.app.id=${APPID} \
+    -Dquarkus.http.port=${SERVICE_PORT} \
+    -jar ./service-0.7.0-SNAPSHOT-runner.jar
 CMD [ "" ]

--- a/helm/theia.cloud/templates/landing-page-config-map.yaml
+++ b/helm/theia.cloud/templates/landing-page-config-map.yaml
@@ -13,7 +13,7 @@ data:
       keycloakAuthUrl: "{{ .Values.keycloak.authUrl }}",
       keycloakRealm: "{{ .Values.keycloak.realm }}",
       keycloakClientId: "{{ .Values.keycloak.clientId }}",
-      serviceUrl: "{{ .Values.hosts.serviceProtocol }}://{{ .Values.hosts.service }}{{ if .Values.hosts.useServicePortInHostname }}:8081{{ end }}",
+      serviceUrl: "{{ .Values.hosts.serviceProtocol }}://{{ .Values.hosts.service }}{{ if .Values.hosts.useServicePortInHostname }}:{{ .Values.hosts.servicePort }}{{ end }}",
       appDefinition: "{{ .Values.landingPage.appDefinition }}",
     };
 binaryData:

--- a/helm/theia.cloud/templates/operator.yaml
+++ b/helm/theia.cloud/templates/operator.yaml
@@ -29,7 +29,7 @@ spec:
           - "--bandwidthLimiter"
           - {{ .Values.operator.bandwidthLimiter }}
           - "--serviceUrl"
-          - {{ .Values.hosts.serviceProtocol }}://{{ .Values.hosts.service }}{{ if .Values.hosts.useServicePortInHostname }}:8081{{ end }}
+          - {{ .Values.hosts.serviceProtocol }}://{{ .Values.hosts.service }}{{ if .Values.hosts.useServicePortInHostname }}:{{ .Values.hosts.servicePort }}{{ end }}
           - "--sessionsPerUser"
           - "{{ .Values.operator.sessionsPerUser }}"
           - "--appId"

--- a/helm/theia.cloud/templates/service-configmap.yaml
+++ b/helm/theia.cloud/templates/service-configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   APPID: {{ .Values.app.id }}
+  SERVICE_PORT: {{ .Values.hosts.servicePort | quote }}

--- a/helm/theia.cloud/templates/service-ingress.yaml
+++ b/helm/theia.cloud/templates/service-ingress.yaml
@@ -20,6 +20,6 @@ spec:
           service:
             name: service-service
             port:
-              number: 8081
+              number: {{ .Values.hosts.servicePort }}
         path: /service
         pathType: ImplementationSpecific

--- a/helm/theia.cloud/templates/service.yaml
+++ b/helm/theia.cloud/templates/service.yaml
@@ -23,7 +23,7 @@ spec:
         image: {{ .Values.service.image }}
         ports:
         - name: http
-          containerPort: 8081
+          containerPort: {{ .Values.hosts.servicePort }}
           protocol: TCP
         envFrom:
         - configMapRef:
@@ -47,5 +47,5 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      port: 8081
-      targetPort: 8081
+      port: {{ .Values.hosts.servicePort }}
+      targetPort: {{ .Values.hosts.servicePort }}

--- a/helm/theia.cloud/values.yaml
+++ b/helm/theia.cloud/values.yaml
@@ -40,6 +40,9 @@ hosts:
   # protocol of the REST-API
   serviceProtocol: https
 
+  # service port (default: 8081)
+  servicePort: 8081
+
   # whether the service port needs to be part of the service URL (default: false)
   useServicePortInHostname: false
 

--- a/java/common/maven-conf/pom.xml
+++ b/java/common/maven-conf/pom.xml
@@ -21,8 +21,8 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-		<quarkus.platform.version>2.7.0.Final</quarkus.platform.version>
-		<surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+		<quarkus.platform.version>2.12.0.Final</quarkus.platform.version>
+		<surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
 	</properties>
 
 </project>

--- a/java/service/org.eclipse.theia.cloud.service/.classpath
+++ b/java/service/org.eclipse.theia.cloud.service/.classpath
@@ -28,14 +28,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="src" path=".apt_generated">
 		<attributes>
 			<attribute name="optional" value="true"/>
@@ -44,15 +36,6 @@
 	<classpathentry kind="src" output="target/test-classes" path=".apt_generated_tests">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/java/service/org.eclipse.theia.cloud.service/pom.xml
+++ b/java/service/org.eclipse.theia.cloud.service/pom.xml
@@ -24,34 +24,11 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
 	<dependencies>
-		<dependency>
-			<groupId>org.eclipse.theia.cloud</groupId>
-			<artifactId>common</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
-
-		<dependency>
-			<groupId>io.fabric8</groupId>
-			<artifactId>kubernetes-client</artifactId>
-			<version>${kubernetes-client.version}</version><!--$NO-MVN-MAN-VER$-->
-		</dependency>
-		<dependency>
-			<groupId>io.quarkus</groupId>
-			<artifactId>quarkus-resteasy-jackson</artifactId>
-		</dependency>
+		<!-- Base Quarkus -->
 		<dependency>
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-arc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.quarkus</groupId>
-			<artifactId>quarkus-resteasy</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.quarkus</groupId>
-			<artifactId>quarkus-smallrye-openapi</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus</groupId>
@@ -63,8 +40,41 @@
 			<artifactId>rest-assured</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- Quarkus Extensions -->
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-resteasy</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-resteasy-jackson</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-smallrye-openapi</artifactId>
+		</dependency>
+		<!-- Theia.cloud Dependencies -->
+		<dependency>
+			<groupId>org.eclipse.theia.cloud</groupId>
+			<artifactId>common</artifactId>
+			<version>0.7.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>kubernetes-client</artifactId>
+			<version>${kubernetes-client.version}</version><!--$NO-MVN-MAN-VER$ -->
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j.version}</version><!--$NO-MVN-MAN-VER$-->
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j.version}</version>
+		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -103,9 +113,27 @@
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${surefire-plugin.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<systemPropertyVariables>
+								<native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+								<java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+								<maven.home>${maven.home}</maven.home>
+							</systemPropertyVariables>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
-
 	<profiles>
 		<profile>
 			<id>native</id>
@@ -114,29 +142,6 @@
 					<name>native</name>
 				</property>
 			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-failsafe-plugin</artifactId>
-						<version>${surefire-plugin.version}</version>
-						<executions>
-							<execution>
-								<goals>
-									<goal>integration-test</goal>
-									<goal>verify</goal>
-								</goals>
-								<configuration>
-									<systemPropertyVariables>
-										<native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-										<java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-										<maven.home>${maven.home}</maven.home>
-									</systemPropertyVariables>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 			<properties>
 				<quarkus.package.type>native</quarkus.package.type>
 			</properties>

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/ApplicationLifecycleListener.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/ApplicationLifecycleListener.java
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.jboss.logging.Logger;
+
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.core.json.JsonObject;
+
+@ApplicationScoped
+public class ApplicationLifecycleListener {
+    protected Logger logger;
+
+    protected void onStart(@Observes StartupEvent event) {
+	logger = Logger.getLogger(getClass());
+	logConfiguration();
+    }
+
+    private void logConfiguration() {
+	logConfigurationSources();
+	logQuarkusConfiguration();
+    }
+
+    private void logConfigurationSources() {
+	for (ConfigSource configSource : ConfigProvider.getConfig().getConfigSources()) {
+	    logger.info(configSource.getName() + " (" + configSource.getOrdinal() + ")");
+	    logger.info(new JsonObject(new HashMap<String, Object>(configSource.getProperties())).encodePrettily());
+	}
+    }
+
+    private void logQuarkusConfiguration() {
+	Config configuration = ConfigProvider.getConfig();
+	Map<String, Object> quarkusProperties = StreamSupport
+		.stream(configuration.getPropertyNames().spliterator(), false).filter(this::isQuarkusProperty) //
+		.collect(Collectors.toMap(Function.identity(),
+			property -> configuration.getValue(property, String.class)));
+	logger.info("Resulting Quarkus Configuration");
+	logger.info(new JsonObject(quarkusProperties).encodePrettily());
+    }
+
+    private boolean isQuarkusProperty(Object name) {
+	return name.toString().startsWith("quarkus.");
+    }
+
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/resources/application.properties
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.http.port=8081
 quarkus.http.cors=true
+quarkus.http.read-timeout=5M


### PR DESCRIPTION
- Upgrade to Quarkus 2.12 for additional properties
- Increase default http read timeout to 5M
- Allow customization of service port (default: 8081)
- Print Quarkus configuration to debug on startup