### PR TITLE
Set runtime user and group only for application container

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -63,9 +63,10 @@ spec:
             value: placeholder-env-session-user
           - name: THEIA_CLOUD_SESSION_URL
             value: placeholder-env-session-url
+          securityContext:
+            runAsUser: placeholder-uid
+            runAsGroup: placeholder-uid
       securityContext:
-        runAsUser: placeholder-uid
-        runAsGroup: placeholder-uid
         fsGroup: placeholder-uid
       volumes:
         - name: oauth2-proxy-config


### PR DESCRIPTION
Before, we set the runtime user and group for all containers in workspace pods. This included the OAuth proxy.
This could lead to undesired behavior when running the OAuth proxy or other sidecars with the app's user id.

This commit moves the user and group configuration down to the actual application container.