### PR TITLE
Pin landing-page Docker container to node 16.x

### DIFF
--- a/dockerfiles/landing-page/Dockerfile
+++ b/dockerfiles/landing-page/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:16-alpine as build-stage
 WORKDIR /app
 COPY node/landing-page/package*.json ./
 RUN yarn install

--- a/dockerfiles/try-now-page/Dockerfile
+++ b/dockerfiles/try-now-page/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:lts-alpine as build-stage
+FROM node:16-alpine as build-stage
 # disable eslint during build
 ENV DISABLE_ESLINT_PLUGIN=true
 WORKDIR /app


### PR DESCRIPTION
Make upgrading from one node LTS version to the next an explicit action by using a specific LTS version in the Dockerfile.

Use node:16-alpine to ensure we get nodejs 16.x, the current source does not compile using node 18.x.