### PR TITLE
Add WebView support

### DIFF
--- a/helm/theia.cloud/templates/instances-ingress.yaml
+++ b/helm/theia.cloud/templates/instances-ingress.yaml
@@ -16,8 +16,10 @@ spec:
   tls: 
   - hosts:
     - {{ tpl (.Values.hosts.instance | toString) . }}
+    - "*.webview.{{ tpl (.Values.hosts.instance | toString) . }}"
     secretName: ws-cert-secret
   rules:
     - host: {{ tpl (.Values.hosts.instance | toString) . }}
       http:
-      
+    - host: "*.webview.{{ .Values.hosts.instance }}"
+      http:

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazySessionHandler.java
@@ -159,9 +159,11 @@ public class LazySessionHandler implements SessionHandler {
 		storageName, arguments.isUseKeycloak());
 
 	/* adjust the ingress */
+	String webViewHost;
 	String host;
 	try {
-	    host = updateIngress(ingress, serviceToUse, session, appDefinition, correlationId);
+	    host = updateIngress(ingress, serviceToUse, session, appDefinition, correlationId, "");
+	    webViewHost = updateIngress(ingress, serviceToUse, session, appDefinition, correlationId, "*.webview.");
 	} catch (KubernetesClientException e) {
 	    LOGGER.error(formatLogMessage(correlationId,
 		    "Error while editing ingress " + ingress.get().getMetadata().getName()), e);
@@ -366,8 +368,8 @@ public class LazySessionHandler implements SessionHandler {
     }
 
     protected synchronized String updateIngress(Optional<Ingress> ingress, Optional<Service> serviceToUse,
-	    Session session, AppDefinition appDefinition, String correlationId) {
-	String host = appDefinition.getSpec().getHost();
+	    Session session, AppDefinition appDefinition, String correlationId, String prefix) {
+	String host = prefix + appDefinition.getSpec().getHost();
 	String path = ingressPathProvider.getPath(appDefinition, session);
 	client.ingresses().edit(correlationId, ingress.get().getMetadata().getName(), ingressToUpdate -> {
 	    IngressRule ingressRule = new IngressRule();

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateIngress.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateIngress.yaml
@@ -32,3 +32,5 @@ spec:
         #         name: nginx-ok-service
         #         port:
         #           number: 80 
+    - host: "*.webview.placeholder-host"
+      http:


### PR DESCRIPTION
Webviews use a subdomain of the service URL, in a format similar to `<webview ID>.webview.<service host>/`

This commit updates the integress template to add a wildcard support for *.webview, and updates the `LazySessionHandler` to add routes for the *.webview domain.