### PR TITLE
Only configure service's keycloak parameters for enabled keycloak

### DIFF
--- a/dockerfiles/service/Dockerfile
+++ b/dockerfiles/service/Dockerfile
@@ -25,7 +25,6 @@ ENV KEYCLOAK_CLIENTSECRET publicbutoauth2proxywantsasecret
 ENTRYPOINT java -Dtheia.cloud.app.id=${APPID} \
     -Dquarkus.http.port=${SERVICE_PORT} \
     -Dtheia.cloud.use.keycloak=${KEYCLOAK_ENABLE} \
-    -Dquarkus.oidc.enabled=${KEYCLOAK_ENABLE} \
     -Dquarkus.oidc.auth-server-url=${KEYCLOAK_SERVERURL} \
     -Dquarkus.oidc.client-id=${KEYCLOAK_CLIENTID} \
     -Dquarkus.oidc.credentials.secret=${KEYCLOAK_CLIENTSECRET} \

--- a/helm/theia.cloud/templates/service-configmap.yaml
+++ b/helm/theia.cloud/templates/service-configmap.yaml
@@ -7,6 +7,8 @@ data:
   APPID: {{ tpl (.Values.app.id | toString) . }}
   SERVICE_PORT: {{ tpl (.Values.hosts.servicePort | toString) . | quote }}
   KEYCLOAK_ENABLE: {{ tpl (.Values.keycloak.enable | toString) . | quote }}
+  {{- if eq (tpl (.Values.keycloak.enable | toString) .) "true" }}
   KEYCLOAK_SERVERURL: {{ tpl (.Values.keycloak.authUrl | toString) . }}realms/{{ tpl (.Values.keycloak.realm | toString) . }}
   KEYCLOAK_CLIENTID: {{ tpl (.Values.keycloak.clientId | toString) . }}
   KEYCLOAK_CLIENTSECRET: {{ tpl (.Values.keycloak.clientSecret | toString) . }}
+  {{- end }}

--- a/helm/theia.cloud/valuesGKETryNow.yaml
+++ b/helm/theia.cloud/valuesGKETryNow.yaml
@@ -30,10 +30,10 @@ landingPage:
 
 keycloak:
   enable: false
-  authUrl: "https://keycloak.34.141.62.32.nip.io"
+  authUrl: ""
   realm: ""
-  clientId: "id"
-  clientSecret: "secret"
+  clientId: ""
+  clientSecret: ""
   cookieSecret: ""
 
 operator:


### PR DESCRIPTION
Improve the service configmap template to only contain keycloak parameters (e.g. the server url) if keycloak is enabled. This prevents empty values overriding the docker image's defaults. Before this change, this could lead to  errors in the service.

Additionally, no longer hand in property `quarkus.oidc.enabled` at runtime to the service because this property can only be set at build time.

Remove workaround keycloak values from `valuesGKETryNow.yaml` again.

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>

## Note for testing

You can test the generation of the generated kubernetes resources with the `helm template` command without needing to deploy the chart.
E.g.: `helm template ./helm/theia.cloud --values ./helm/theia.cloud/valuesGKETryNow.yaml > test.yaml`