### PR TITLE
Same base url for all components

### DIFF
--- a/doc/docs/Install.md
+++ b/doc/docs/Install.md
@@ -18,6 +18,22 @@ As of writing this guide the installation command looks like this:\
 Follow the installation guide for your platform:\
 https://kubernetes.github.io/ingress-nginx/deploy/
 
+### Global certificate (Only when using paths)
+
+If Theia Cloud is used with paths instead of subdomains, the global HTTPS certificate should exist and be configured as the NginX Ingress Controller's default certificate.
+
+You can either provide the default certificate yourself or use a dummy service to initially generate the certificate.
+In [global-certificate.yaml](./platforms/global-certificate.yaml), replace `example.com` with your own host and `letsencrypt-prod` with your certificate issuer of choice.
+Apply the configuration with `kubectl apply -f  ./doc/docs/platforms/global-certificate.yaml`.
+
+Configure the nginx controllers deployment to use the certificate `default-tls` in the default namespace as its default certificate.
+For this, add argument `"--default-ssl-certificate=default/default-tls"` to the container by patching the controller's deployment.
+
+```bash
+kubectl patch deploy ingress-nginx-controller --type='json' -n ingress-nginx \
+-p '[{ "op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--default-ssl-certificate=default/default-tls" }]'
+```
+
 ### Optional: Keycloak
 
 ## Install

--- a/doc/docs/platforms/Minikube.md
+++ b/doc/docs/platforms/Minikube.md
@@ -51,6 +51,21 @@ This is installed in minikube already when started with the `--addons=ingress` a
 
 If you want to run the Minikube-Demo path on an actual cluster, please see https://kubernetes.github.io/ingress-nginx/deploy/ on how to install the controller.
 
+### Global certificate - ONLY when using paths
+
+If Theia Cloud is used with paths instead of subdomains, the global HTTPS certificate should exist and be configured as the NginX Ingress Controller's default certificate.
+
+In [global-certificate.yaml](./platforms/global-certificate.yaml), replace `example.com` with `$(minikube ip).nip.io`  and `letsencrypt-prod` with `theia-cloud-selfsigned-issuer`.
+Apply the configuration with `kubectl apply -f  ./doc/docs/platforms/global-certificate.yaml`.
+
+Configure the nginx controllers deployment to use the certificate `default-tls` in the default namespace as its default certificate.
+For this, add argument `"--default-ssl-certificate=default/default-tls"` to the container by patching the controller's deployment.
+
+```bash
+kubectl patch deploy ingress-nginx-controller --type='json' -n ingress-nginx \
+-p '[{ "op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--default-ssl-certificate=default/default-tls" }]'
+```
+
 ### Keycloak
 
 Keycloak is the identify and access management tool used by Theia.Cloud.

--- a/doc/docs/platforms/global-certificate.yaml
+++ b/doc/docs/platforms/global-certificate.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cert-deployment
+  template:
+    metadata:
+      labels:
+        app: cert-deployment
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: nginx-hello-world
+        image: nginxdemos/hello
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-deployment-service
+  labels:
+    app: cert-deployment
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: cert-deployment
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cert-deployment-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    acme.cert-manager.io/http01-edit-in-place: "true"
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: default-tls
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /cert
+        pathType: Prefix
+        backend:
+          service:
+            name: cert-deployment-service
+            port:
+              number: 80

--- a/helm/theia.cloud/templates/instances-ingress.yaml
+++ b/helm/theia.cloud/templates/instances-ingress.yaml
@@ -5,19 +5,30 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     {{ if .Values.ingress.theiaCloudCommonName }}cert-manager.io/common-name: "Theia.Cloud" {{ end }}
     acme.cert-manager.io/http01-ingress-class: nginx
+    {{- end }}
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header 'X-Forwarded-Uri' $request_uri;
 spec:
-  tls: 
+  tls:
   - hosts:
+  {{- if .Values.hosts.usePaths }}
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+    secretName: universal-cert-secret
+  {{- else }}
     - {{ tpl (.Values.hosts.instance | toString) . }}
     secretName: ws-cert-secret
+  {{- end }}
   rules:
+    {{- if .Values.hosts.usePaths }}
+    - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+    {{- else }}
     - host: {{ tpl (.Values.hosts.instance | toString) . }}
+    {{- end }}
       http:
       

--- a/helm/theia.cloud/templates/instances-ingress.yaml
+++ b/helm/theia.cloud/templates/instances-ingress.yaml
@@ -19,7 +19,6 @@ spec:
   - hosts:
   {{- if .Values.hosts.usePaths }}
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
-    secretName: universal-cert-secret
   {{- else }}
     - {{ tpl (.Values.hosts.instance | toString) . }}
     secretName: ws-cert-secret

--- a/helm/theia.cloud/templates/landing-page-config-map.yaml
+++ b/helm/theia.cloud/templates/landing-page-config-map.yaml
@@ -13,7 +13,11 @@ data:
       keycloakAuthUrl: "{{ tpl (.Values.keycloak.authUrl | toString) . }}",
       keycloakRealm: "{{ tpl (.Values.keycloak.realm | toString) . }}",
       keycloakClientId: "{{ tpl (.Values.keycloak.clientId | toString) . }}",
+      {{- if .Values.hosts.usePaths }}
+      serviceUrl: "{{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.paths.baseHost | toString) . }}/{{ tpl (.Values.hosts.paths.service | toString) . }}",
+      {{- else }}
       serviceUrl: "{{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.service | toString) . }}{{ if .Values.hosts.useServicePortInHostname }}:{{ tpl (.Values.hosts.servicePort | toString) . }}{{ end }}",
+      {{- end }}
       appDefinition: "{{ tpl (.Values.landingPage.appDefinition | toString) . }}",
       additionalApps: [
         {{- range $key, $val := .Values.landingPage.additionalApps }}

--- a/helm/theia.cloud/templates/landing-page-ingress.yaml
+++ b/helm/theia.cloud/templates/landing-page-ingress.yaml
@@ -4,16 +4,29 @@ metadata:
   name: landing-page-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
-  tls: 
+  tls:
   - hosts:
+  {{- if .Values.hosts.usePaths }}
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+    secretName: universal-cert-secret
+  {{- else }}
     - {{ tpl (.Values.hosts.landing | toString) . }}
     secretName: landing-page-cert-secret
+  {{- end }}
   rules:
+  {{- if .Values.hosts.usePaths }}
+  - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
   - host: {{ tpl (.Values.hosts.landing | toString) . }}
+  {{- end }}
     http:
       paths:
       - backend:
@@ -21,5 +34,5 @@ spec:
             name: landing-page-service
             port:
               number: 80
-        path: /
+        path: /{{ if .Values.hosts.usePaths }}{{ tpl (.Values.hosts.paths.landing | toString) . }}(/|$)(.*){{ end }}
         pathType: Prefix

--- a/helm/theia.cloud/templates/landing-page-ingress.yaml
+++ b/helm/theia.cloud/templates/landing-page-ingress.yaml
@@ -16,7 +16,6 @@ spec:
   - hosts:
   {{- if .Values.hosts.usePaths }}
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
-    secretName: universal-cert-secret
   {{- else }}
     - {{ tpl (.Values.hosts.landing | toString) . }}
     secretName: landing-page-cert-secret

--- a/helm/theia.cloud/templates/operator.yaml
+++ b/helm/theia.cloud/templates/operator.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: operator-container
         image: {{ tpl (.Values.operator.image | toString) . }}
+        imagePullPolicy: IfNotPresent
         args:
           {{ if .Values.keycloak.enable }}- "--keycloak"{{ end }}
           {{ if .Values.operator.eagerStart }}- "--eagerStart"{{ end }}
@@ -29,11 +30,20 @@ spec:
           - "--bandwidthLimiter"
           - {{ tpl (.Values.operator.bandwidthLimiter | toString) . }}
           - "--serviceUrl"
+          {{- if .Values.hosts.usePaths }}
+          - {{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.paths.baseHost | toString) . }}/{{ tpl (.Values.hosts.paths.service | toString) . }}
+          {{- else}}
           - {{ tpl (.Values.hosts.serviceProtocol | toString) . }}://{{ tpl (.Values.hosts.service | toString) . }}{{ if .Values.hosts.useServicePortInHostname }}:{{ tpl (.Values.hosts.servicePort | toString) . }}{{ end }}
+          {{- end }}
           - "--sessionsPerUser"
           - "{{ tpl (.Values.operator.sessionsPerUser | toString) . }}"
           - "--appId"
           - {{ tpl (.Values.app.id | toString) . }}
+          {{- if .Values.hosts.usePaths }}
+          - "--usePaths"
+          - "--instancesPath"
+          - "{{ tpl (.Values.hosts.paths.instance | toString) . }}"
+          {{- end }}
       {{- if .Values.operator.imagePullSecret }}
       imagePullSecrets:
         - name: {{ tpl (.Values.operator.imagePullSecret | toString) . }}

--- a/helm/theia.cloud/templates/service-ingress.yaml
+++ b/helm/theia.cloud/templates/service-ingress.yaml
@@ -6,14 +6,27 @@ metadata:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- if .Values.ingress.theiaCloudCommonName }}
+    cert-manager.io/common-name: "Theia.Cloud"
+    {{- end }}
+    nginx.ingress.kubernetes.io/rewrite-target: /service$1
   namespace: {{ .Release.Namespace }}
 spec:
-  tls: 
+  tls:
   - hosts:
+  {{- if .Values.hosts.usePaths }}
+    - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+    secretName: universal-cert-secret
+  {{- else }}
     - {{ tpl (.Values.hosts.service | toString) . }}
     secretName: service-cert-secret
+  {{- end }}
   rules:
+  {{- if .Values.hosts.usePaths }}
+  - host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
   - host: {{ tpl (.Values.hosts.service | toString) . }}
+  {{- end }}
     http:
       paths:
       - backend:
@@ -21,5 +34,5 @@ spec:
             name: service-service
             port:
               number: {{ tpl (.Values.hosts.servicePort | toString) . }}
-        path: /service
+        path: {{ if .Values.hosts.usePaths }}/{{ tpl (.Values.hosts.paths.service | toString) . }}{{ end }}/service($|(/.*))
         pathType: ImplementationSpecific

--- a/helm/theia.cloud/templates/service-ingress.yaml
+++ b/helm/theia.cloud/templates/service-ingress.yaml
@@ -4,10 +4,12 @@ metadata:
   name: service-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    {{- if not .Values.hosts.usePaths }}
     cert-manager.io/cluster-issuer: {{ tpl (.Values.ingress.clusterIssuer | toString) . }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- if .Values.ingress.theiaCloudCommonName }}
     cert-manager.io/common-name: "Theia.Cloud"
+    {{- end }}
     {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /service$1
   namespace: {{ .Release.Namespace }}
@@ -16,7 +18,6 @@ spec:
   - hosts:
   {{- if .Values.hosts.usePaths }}
     - {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
-    secretName: universal-cert-secret
   {{- else }}
     - {{ tpl (.Values.hosts.service | toString) . }}
     secretName: service-cert-secret

--- a/helm/theia.cloud/templates/theia-appdefinition-spec.yaml
+++ b/helm/theia.cloud/templates/theia-appdefinition-spec.yaml
@@ -8,7 +8,11 @@ spec:
   pullSecret: {{ tpl (.Values.image.pullSecret | toString) . }}
   uid: 101
   port: 3000
+  {{- if .Values.hosts.usePaths }}
+  host: {{ tpl (.Values.hosts.paths.baseHost | toString) . }}
+  {{- else }}
   host: {{ tpl (.Values.hosts.instance | toString) . }}
+  {{- end }}
   ingressname: theia-cloud-demo-ws-ingress
   minInstances: 0
   maxInstances: 10

--- a/helm/theia.cloud/values.yaml
+++ b/helm/theia.cloud/values.yaml
@@ -34,6 +34,20 @@ image:
 
 # You may adjust the hostname below.
 hosts:
+
+  # Use paths configures that all services should run on the same host but on different paths.
+  # true uses paths
+  # false uses an explicit host for each service
+  usePaths: false
+
+  # Only needed when usePaths == true. Contains the baseHost and paths for all services
+  paths:
+    # baseHost configures the host for all services when usePaths == true. Otherwise the explicit host definitions of the services are used.
+    baseHost: 192.168.39.173.nip.io
+    service: servicex
+    landing: "trynow"
+    instance: ws
+
   # hostname of the REST-API
   service: service.192.168.39.173.nip.io
 

--- a/helm/theia.cloud/valuesMinikubeWithPaths.yaml
+++ b/helm/theia.cloud/valuesMinikubeWithPaths.yaml
@@ -1,0 +1,68 @@
+app:
+  id: asdfghjkl
+  name: Theia Blueprint
+  logo: theiablueprint.svg
+
+issuer:
+  email: mmorlock@example.com
+
+image:
+  name: theiacloud/theia-cloud-demo:0.8.0.MS7
+  pullSecret: ""
+  timeoutStrategy: "FIXEDTIME"
+  timeoutLimit: "30"
+
+hosts:
+   # Use paths configures that all services should run on the same host but on different paths.
+  # true uses paths
+  # false uses an explicit host for each service
+  usePaths: true
+
+  # Only needed when usePaths == true. Contains the baseHost and paths for all services
+  paths:
+    # baseHost configures the host for all services when usePaths == true. Otherwise the explicit host definitions of the services are used.
+    baseHost: 192.168.39.6.nip.io
+    service: servicex
+    landing: trynow
+    instance: instances
+
+  # service: service.192.168.39.6.nip.io
+  serviceProtocol: https
+  # landing: theia.cloud.192.168.39.6.nip.io
+  # instance: ws.192.168.39.6.nip.io
+
+landingPage:
+  image: theia-cloud-try-now-page:paths-1
+  # imagePullSecret: pullsecret
+  appDefinition: "theia-cloud-demo"
+  ephemeralStorage: true
+  # additionalApps: 
+  #   coffee-editor:
+  #     label: "Coffee Editor"
+  #   cdt-cloud-demo:
+  #     label: "CDT.cloud Blueprint"
+
+keycloak:
+  enable: false
+  authUrl: "https://keycloak.192.168.39.6.nip.io/auth/"
+  realm: "TheiaCloud"
+  clientId: "theia-cloud"
+  clientSecret: "publicbutoauth2proxywantsasecret"
+  cookieSecret: "OQINaROshtE9TcZkNAm5Zs2Pv3xaWytBmc5W7sPX7ws="
+
+operator:
+  image: theia-cloud-operator:osw-paths-0
+  # imagePullSecret: pullsecret
+  eagerStart: false
+  cloudProvider: "K8S"
+  bandwidthLimiter: "K8SANNOTATION"
+  sessionsPerUser: "1"
+
+service:
+  image: theiacloud/theia-cloud-service:0.8.0.MS7
+  # imagePullSecret: pullsecret
+
+ingress:
+  instanceName: "theia-cloud-demo-ws-ingress"
+  clusterIssuer: theia-cloud-selfsigned-issuer
+  theiaCloudCommonName: true

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
@@ -52,6 +52,13 @@ public class TheiaCloudArguments {
     @Option(names = { "--appId" }, description = "Application ID necessary for service calls", required = false)
     private String appId;
 
+    @Option(names = {
+	    "--usePaths" }, description = "Whether paths instead of subdomains are used for the various components", required = false)
+    private boolean usePaths;
+
+    @Option(names = { "--instancesPath" }, description = "Subpath instances are hosted at", required = false)
+    private String instancesPath;
+
     public boolean isUseKeycloak() {
 	return useKeycloak;
     }
@@ -80,6 +87,14 @@ public class TheiaCloudArguments {
 	return appId;
     }
 
+    public boolean isUsePaths() {
+	return usePaths;
+    }
+
+    public String getInstancesPath() {
+	return instancesPath;
+    }
+
     @Override
     public int hashCode() {
 	final int prime = 31;
@@ -91,6 +106,8 @@ public class TheiaCloudArguments {
 	result = prime * result + ((serviceUrl == null) ? 0 : serviceUrl.hashCode());
 	result = prime * result + ((sessionsPerUser == null) ? 0 : sessionsPerUser.hashCode());
 	result = prime * result + (useKeycloak ? 1231 : 1237);
+	result = prime * result + (usePaths ? 1231 : 1237);
+	result = prime * result + ((instancesPath == null) ? 0 : instancesPath.hashCode());
 	return result;
     }
 
@@ -126,6 +143,14 @@ public class TheiaCloudArguments {
 	    return false;
 	if (useKeycloak != other.useKeycloak)
 	    return false;
+	if (usePaths != other.usePaths) {
+	    return false;
+	}
+	if (instancesPath == null) {
+	    if (other.instancesPath != null)
+		return false;
+	} else if (!instancesPath.equals(other.instancesPath))
+	    return false;
 	return true;
     }
 
@@ -133,7 +158,8 @@ public class TheiaCloudArguments {
     public String toString() {
 	return "TheiaCloudArguments [useKeycloak=" + useKeycloak + ", eagerStart=" + eagerStart + ", cloudProvider="
 		+ cloudProvider + ", bandwidthLimiter=" + bandwidthLimiter + ", serviceUrl=" + serviceUrl
-		+ ", sessionsPerUser=" + sessionsPerUser + ", appId=" + appId + "]";
+		+ ", sessionsPerUser=" + sessionsPerUser + ", appId=" + appId + ", usePaths=" + usePaths
+		+ ", instancesPath=" + instancesPath + "]";
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/AddedHandlerUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/AddedHandlerUtil.java
@@ -114,6 +114,7 @@ public final class AddedHandlerUtil {
 
     }
 
+    // FIXME adjust ingress template to paths
     public static void createAndApplyIngress(NamespacedKubernetesClient client, String namespace, String correlationId,
 	    String templateResourceName, String templateResourceUID, AppDefinition appDefinition) {
 	Map<String, String> replacements = TheiaCloudIngressUtil.getIngressReplacements(namespace, appDefinition);

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/IngressPathProviderImpl.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/IngressPathProviderImpl.java
@@ -16,20 +16,39 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.operator.handler.impl;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.Session;
+import org.eclipse.theia.cloud.operator.TheiaCloudArguments;
 import org.eclipse.theia.cloud.operator.handler.IngressPathProvider;
+
+import com.google.inject.Inject;
 
 public class IngressPathProviderImpl implements IngressPathProvider {
 
+    private static final Logger LOGGER = LogManager.getLogger(IngressPathProviderImpl.class);
+
+    @Inject
+    TheiaCloudArguments arguments;
+
     @Override
     public String getPath(AppDefinition appDefinition, int instance) {
-	return "/" + appDefinition.getSpec() + "-" + instance;
+	return getBasePath() + appDefinition.getSpec() + "-" + instance;
     }
 
     @Override
     public String getPath(AppDefinition appDefinition, Session session) {
-	return "/" + session.getMetadata().getUid();
+	return getBasePath() + session.getMetadata().getUid();
     }
 
+    protected String getBasePath() {
+	if (arguments.isUsePaths() && arguments.getInstancesPath() != null && !arguments.getInstancesPath().isBlank()) {
+	    return "/" + arguments.getInstancesPath().trim() + "/";
+	} else if (arguments.isUsePaths()) {
+	    LOGGER.warn(
+		    "Theia cloud is configured to use paths instead of subdomains but no instace subpath was provided");
+	}
+	return "/";
+    }
 }

--- a/node/common/src/client.ts
+++ b/node/common/src/client.ts
@@ -96,8 +96,10 @@ export namespace WorkspaceDeletionRequest {
 export namespace TheiaCloud {
   function basePath(url: string): string {
     // remove any path names as they are provided by the APIs
-    const pathName = new URL(url).pathname;
-    return url.endsWith(pathName) ? url.substring(0, url.length - new URL(url).pathname.length) : url;
+    // TODO Do not remove path names anymore as this is needed for deployment on sub paths. Is this an issue
+    // const pathName = new URL(url).pathname;
+    // return url.endsWith(pathName) ? url.substring(0, url.length - new URL(url).pathname.length) : url;
+    return url;
   }
 
   function rootApi(url: string, accessToken: string | undefined): RootResourceApi {

--- a/node/try-now-page/package.json
+++ b/node/try-now-page/package.json
@@ -2,6 +2,7 @@
   "name": "try-now-page",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@eclipse-theiacloud/common": "0.8.0-alpha.21",
     "@testing-library/jest-dom": "^5.16.4",


### PR DESCRIPTION
Facilitate running all of theia cloud's components on the same base url on different paths.

* Adjust ingress configurations
* Adjust operator
* Adjust try now page and common api

TODO:
* keycloak ingress
* operator ingress creation via template