### PR TITLE
Prevent NPE in TheiaCloudK8sUtil

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazySessionHandler.java
@@ -100,7 +100,7 @@ public class LazySessionHandler implements SessionHandler {
 	}
 	AppDefinition appDefinition = optionalAppDefinition.get();
 
-	if (hasMaxInstancesReachted(appDefinition, session, correlationId)) {
+	if (hasMaxInstancesReached(appDefinition, session, correlationId)) {
 	    return false;
 	}
 
@@ -191,7 +191,7 @@ public class LazySessionHandler implements SessionHandler {
 	}
     }
 
-    protected boolean hasMaxInstancesReachted(AppDefinition appDefinition, Session session, String correlationId) {
+    protected boolean hasMaxInstancesReached(AppDefinition appDefinition, Session session, String correlationId) {
 	if (TheiaCloudK8sUtil.checkIfMaxInstancesReached(client.kubernetes(), client.namespace(), session.getSpec(),
 		appDefinition.getSpec(), correlationId)) {
 	    LOGGER.info(formatLogMessage(correlationId, "Max instances for " + appDefinition.getSpec().getName()

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
@@ -44,11 +44,18 @@ public final class TheiaCloudK8sUtil {
 	    return false;
 	}
 
+	final String appDefinitionName = appDefinitionSpec.getName();
+	if (appDefinitionName == null || appDefinitionName.isBlank()) {
+	    LOGGER.error(
+		    formatLogMessage(correlationId, "The App Definition does not have a name: " + appDefinitionSpec));
+	    return true;
+	}
+
 	long currentInstances = client.resources(Session.class, SessionSpecResourceList.class).inNamespace(namespace)
 		.list().getItems().stream()//
 		.filter(w -> {
-		    String appDefinition = w.getSpec().getAppDefinition();
-		    boolean result = appDefinition.equals(appDefinitionSpec.getName());
+		    String sessionAppDefinition = w.getSpec().getAppDefinition();
+		    boolean result = appDefinitionName.equals(sessionAppDefinition);
 		    LOGGER.trace(formatLogMessage(correlationId, "Counting instances of app definition "
 			    + appDefinitionSpec.getName() + ": Is " + w.getSpec() + " of app definition? " + result));
 		    return result;


### PR DESCRIPTION
- `TheiaCloudK8sUtil.checkIfMaxInstancesReached` could throw an NPE if any Session missed the app definition.
- Misc: Fix typo in protected method name in LazySessionHandler

Fixes #110

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>