### PR TITLE
Update AppDefinitions for CDT Cloud, Coffee Editor, Theia

### DIFF
--- a/demo/k8s/appdefinitions/cdt.yaml
+++ b/demo/k8s/appdefinitions/cdt.yaml
@@ -9,14 +9,14 @@ spec:
   pullSecret: ""
   uid: 101
   port: 3000
-  host: ws.theia-cloud.io
-  ingressname: theia-cloud-demo-ws-ingress
+  host: {{ tpl (.Values.hosts.instance | toString) . }}
+  ingressname: {{ tpl (.Values.ingress.instanceName | toString) . }}
   minInstances: 0
   maxInstances: 10
   timeout:
     limit: 30
     strategy: FIXEDTIME
-  requestsMemory: 1000M
+  requestsMemory: 500M
   limitsMemory: 1200M
   requestsCpu: "100m"
   limitsCpu: "2"

--- a/demo/k8s/appdefinitions/coffee-editor.yaml
+++ b/demo/k8s/appdefinitions/coffee-editor.yaml
@@ -9,8 +9,8 @@ spec:
   pullSecret: ""
   uid: 1000
   port: 3000
-  host: ws.theia-cloud.io
-  ingressname: theia-cloud-demo-ws-ingress
+  host: {{ tpl (.Values.hosts.instance | toString) . }}
+  ingressname: {{ tpl (.Values.ingress.instanceName | toString) . }}
   minInstances: 0
   maxInstances: 10
   timeout:

--- a/demo/k8s/appdefinitions/theia.yaml
+++ b/demo/k8s/appdefinitions/theia.yaml
@@ -9,8 +9,8 @@ spec:
   pullSecret: ""
   uid: 101
   port: 3000
-  host: ws.theia-cloud.io
-  ingressname: theia-cloud-demo-ws-ingress
+  host: {{ tpl (.Values.hosts.instance | toString) . }}
+  ingressname: {{ tpl (.Values.ingress.instanceName | toString) . }}
   minInstances: 0
   maxInstances: 10
   timeout:


### PR DESCRIPTION
- Re-use already configured host instance in app definitions
- Re-use already configured ingress name in app definitions
- Use 500M as requested memory for CDT Cloud as it should be sufficient