### PR TITLE
Make imagePullPolicy configurable via helm chart and app definition

### DIFF
--- a/helm/theia.cloud/crds/appdefinition-spec-resource.yaml
+++ b/helm/theia.cloud/crds/appdefinition-spec-resource.yaml
@@ -25,6 +25,9 @@ spec:
                   type: string
                 image:
                   type: string
+                imagePullPolicy:
+                  type: string
+                  enum: ["Always", "IfNotPresent", "Never"]
                 pullSecret:
                   type: string
                 uid:

--- a/helm/theia.cloud/templates/landing-page.yaml
+++ b/helm/theia.cloud/templates/landing-page.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: landing-page-container
           image: {{ tpl (.Values.landingPage.image | toString) . }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ if .Values.landingPage.imagePullPolicy }}{{ tpl (.Values.landingPage.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
           ports:
             - name: http
               containerPort: 80

--- a/helm/theia.cloud/templates/operator.yaml
+++ b/helm/theia.cloud/templates/operator.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - name: operator-container
         image: {{ tpl (.Values.operator.image | toString) . }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ if .Values.operator.imagePullPolicy }}{{ tpl (.Values.operator.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
         args:
           {{ if .Values.keycloak.enable }}- "--keycloak"{{ end }}
           {{ if .Values.operator.eagerStart }}- "--eagerStart"{{ end }}

--- a/helm/theia.cloud/templates/service.yaml
+++ b/helm/theia.cloud/templates/service.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: service-container
         image: {{ tpl (.Values.service.image | toString) . }}
+        imagePullPolicy: {{ if .Values.service.imagePullPolicy }}{{ tpl (.Values.service.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
         ports:
         - name: http
           containerPort: {{ tpl (.Values.hosts.servicePort | toString) . }}

--- a/helm/theia.cloud/templates/theia-appdefinition-spec.yaml
+++ b/helm/theia.cloud/templates/theia-appdefinition-spec.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   name: theia-cloud-demo
   image: {{ tpl (.Values.image.name | toString) . }}
+  imagePullPolicy: {{ if .Values.image.imagePullPolicy }}{{ tpl (.Values.image.imagePullPolicy | toString) . }}{{ else }}{{ tpl (.Values.imagePullPolicy | toString) . }}{{ end }}
   pullSecret: {{ tpl (.Values.image.pullSecret | toString) . }}
   uid: 101
   port: 3000

--- a/helm/theia.cloud/values.yaml
+++ b/helm/theia.cloud/values.yaml
@@ -1,3 +1,11 @@
+# The default imagePullPolicy for containers of theia cloud.
+# Can be overridden for individual components by specifying the imagePullPolicy variable there.
+# Possible values:
+# - Always
+# - IfNotPresent
+# - Never
+imagePullPolicy: Always
+
 # General information about the deployed app
 app:
   # The app id which is used in the communication between website and REST-API
@@ -19,6 +27,10 @@ issuer:
 image:
   # The name of docker image to be used
   name: theiacloud/theia-cloud-demo:0.8.0.MS7
+
+  # Optional: Override the imagePullPolicy for the main application's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
 
   # the image pull secret. Leave empty if registry is public
   pullSecret: ""
@@ -71,6 +83,10 @@ landingPage:
   # the landing page image to use
   image: theiacloud/theia-cloud-landing-page:0.8.0.MS7
 
+  # Optional: Override the imagePullPolicy for the landing page's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
+
   # Optional: the image pull secret
   imagePullSecret: pullsecret
 
@@ -121,6 +137,10 @@ operator:
   # The operator image
   image: theiacloud/theia-cloud-operator:0.8.0.MS7
 
+  # Optional: Override the imagePullPolicy for the operator's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
+
   # Optional: the image pull secret
   imagePullSecret: pullsecret
 
@@ -153,6 +173,10 @@ operator:
 service:
   # The image to use
   image: theiacloud/theia-cloud-service:0.8.0.MS7
+
+  # Optional: Override the imagePullPolicy for the service's docker image.
+  # If this is omitted or empty, the root at .Values.imagePullPolicy is used.
+  # imagePullPolicy: IfNotPresent
 
   # Optional: the image pull secret
   imagePullSecret: pullsecret

--- a/helm/theia.cloud/valuesCDT.yaml
+++ b/helm/theia.cloud/valuesCDT.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: Always
+
 app:
   id: asdfghjkl
   name: CDT.cloud Blueprint

--- a/helm/theia.cloud/valuesGKETryNow.yaml
+++ b/helm/theia.cloud/valuesGKETryNow.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: Always
+
 app:
   id: asdfghjkl
   name: Theia Blueprint

--- a/helm/theia.cloud/valuesGKETryNowCDT.yaml
+++ b/helm/theia.cloud/valuesGKETryNowCDT.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: Always
+
 app:
   id: asdfghjkl
   name: CDT.cloud Blueprint

--- a/helm/theia.cloud/valuesMinikube.yaml
+++ b/helm/theia.cloud/valuesMinikube.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: IfNotPresent
+
 app:
   id: asdfghjkl
   name: Theia Blueprint

--- a/helm/theia.cloud/valuesMinikubeCDT.yaml
+++ b/helm/theia.cloud/valuesMinikubeCDT.yaml
@@ -1,3 +1,5 @@
+imagePullPolicy: IfNotPresent
+
 app:
   id: asdfghjkl
   name: CDT.cloud Blueprint

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinitionSpec.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinitionSpec.java
@@ -32,6 +32,9 @@ public class AppDefinitionSpec {
     @JsonProperty("image")
     private String image;
 
+    @JsonProperty("imagePullPolicy")
+    private String imagePullPolicy;
+
     @JsonProperty("pullSecret")
     private String pullSecret;
 
@@ -83,6 +86,10 @@ public class AppDefinitionSpec {
 
     public String getImage() {
 	return image;
+    }
+
+    public String getImagePullPolicy() {
+	return imagePullPolicy;
     }
 
     public String getPullSecret() {
@@ -147,12 +154,12 @@ public class AppDefinitionSpec {
 
     @Override
     public String toString() {
-	return "AppDefinitionSpec [name=" + name + ", image=" + image + ", pullSecret=" + pullSecret + ", uid=" + uid
-		+ ", port=" + port + ", host=" + host + ", ingressname=" + ingressname + ", minInstances="
-		+ minInstances + ", maxInstances=" + maxInstances + ", timeout=" + timeout + ", requestsMemory="
-		+ requestsMemory + ", requestsCpu=" + requestsCpu + ", limitsMemory=" + limitsMemory + ", limitsCpu="
-		+ limitsCpu + ", downlinkLimit=" + downlinkLimit + ", uplinkLimit=" + uplinkLimit + ", mountPath="
-		+ mountPath + "]";
+	return "AppDefinitionSpec [name=" + name + ", image=" + image + ", imagePullPolicy=" + imagePullPolicy
+		+ ", pullSecret=" + pullSecret + ", uid=" + uid + ", port=" + port + ", host=" + host + ", ingressname="
+		+ ingressname + ", minInstances=" + minInstances + ", maxInstances=" + maxInstances + ", timeout="
+		+ timeout + ", requestsMemory=" + requestsMemory + ", requestsCpu=" + requestsCpu + ", limitsMemory="
+		+ limitsMemory + ", limitsCpu=" + limitsCpu + ", downlinkLimit=" + downlinkLimit + ", uplinkLimit="
+		+ uplinkLimit + ", mountPath=" + mountPath + "]";
     }
 
     public static class Timeout {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/DeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/DeploymentTemplateReplacements.java
@@ -28,4 +28,8 @@ public interface DeploymentTemplateReplacements {
     default String orEmpty(String string) {
 	return string == null ? "" : string;
     }
+
+    default String orDefault(String string, String defaultValue) {
+	return string == null ? defaultValue : string;
+    }
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
@@ -40,6 +40,10 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
     public static final String PLACEHOLDER_DEPLOYMENTNAME = "placeholder-depname";
     public static final String PLACEHOLDER_APPDEFINITIONNAME = "placeholder-definitionname";
     public static final String PLACEHOLDER_IMAGE = "placeholder-image";
+    public static final String PLACEHOLDER_IMAGE_PULL_POLICY = "placeholder-pull-policy";
+    // TODO Is "Always" the correct default? Should it be setable as an operator
+    // argument?
+    public static final String DEFAULT_IMAGE_PULL_POLICY = "Always";
     public static final String PLACEHOLDER_CPU_LIMITS = "placeholder-cpu-limits";
     public static final String PLACEHOLDER_MEMORY_LIMITS = "placeholder-memory-limits";
     public static final String PLACEHOLDER_CPU_REQUESTS = "placeholder-cpu-requests";
@@ -85,6 +89,8 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 	Map<String, String> appDefinitionData = new LinkedHashMap<String, String>();
 	appDefinitionData.put(PLACEHOLDER_APPDEFINITIONNAME, appDefinition.getSpec().getName());
 	appDefinitionData.put(PLACEHOLDER_IMAGE, appDefinition.getSpec().getImage());
+	appDefinitionData.put(PLACEHOLDER_IMAGE_PULL_POLICY,
+		orDefault(appDefinition.getSpec().getImagePullPolicy(), DEFAULT_IMAGE_PULL_POLICY));
 	appDefinitionData.put(PLACEHOLDER_PORT, String.valueOf(appDefinition.getSpec().getPort()));
 	appDefinitionData.put(PLACEHOLDER_CPU_LIMITS, orEmpty(appDefinition.getSpec().getLimitsCpu()));
 	appDefinitionData.put(PLACEHOLDER_MEMORY_LIMITS, orEmpty(appDefinition.getSpec().getLimitsMemory()));

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -41,6 +41,7 @@ spec:
               mountPath: /emails
         - name: placeholder-definitionname
           image: placeholder-image
+          imagePullPolicy: placeholder-pull-policy
           ports:
             - containerPort: placeholder-port
           resources:

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeploymentWithoutOAuthProxy.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeploymentWithoutOAuthProxy.yaml
@@ -29,6 +29,7 @@ spec:
       containers:
         - name: placeholder-definitionname
           image: placeholder-image
+          imagePullPolicy: placeholder-pull-policy
           ports:
             - containerPort: placeholder-port
           resources:


### PR DESCRIPTION
### Make application imagePullPolicy configurable in app definitions 

- Extend appdefinition CRD with imagePullPolicy property
- Extend operator to set this for new session pods and provide a fallback value if not specified

### Make containers' imagePullPolicy configurable via helm chart 

- Add root level value `imagePullPolicy` and a value for each component
- Use component-specific value if available, otherwise fall back to root level property
- Extend templates for this
- Extend app definition CRD to store the pull policy
- Add root level property to all values files. Use Always for online and IfNotPresent for Minikube

Fixes #109 

Contributed on behalf of STMicroelectronics