### PR TITLE
Fix vue landing page to work with paths

### DIFF
--- a/node/common/src/client.ts
+++ b/node/common/src/client.ts
@@ -21,6 +21,7 @@ export interface RequestOptions {
 }
 
 export interface ServiceRequest {
+  /** The root URL of the service. */
   serviceUrl: string;
   kind?: string;
 }
@@ -94,24 +95,16 @@ export namespace WorkspaceDeletionRequest {
 }
 
 export namespace TheiaCloud {
-  function basePath(url: string): string {
-    // remove any path names as they are provided by the APIs
-    // TODO Do not remove path names anymore as this is needed for deployment on sub paths. Is this an issue
-    // const pathName = new URL(url).pathname;
-    // return url.endsWith(pathName) ? url.substring(0, url.length - new URL(url).pathname.length) : url;
-    return url;
+  function rootApi(serviceUrl: string, accessToken: string | undefined): RootResourceApi {
+    return new RootResourceApi(new Configuration({ basePath: serviceUrl, accessToken }));
   }
 
-  function rootApi(url: string, accessToken: string | undefined): RootResourceApi {
-    return new RootResourceApi(new Configuration({ basePath: basePath(url), accessToken }));
+  function sessionApi(serviceUrl: string, accessToken: string | undefined): SessionResourceApi {
+    return new SessionResourceApi(new Configuration({ basePath: serviceUrl, accessToken }));
   }
 
-  function sessionApi(url: string, accessToken: string | undefined): SessionResourceApi {
-    return new SessionResourceApi(new Configuration({ basePath: basePath(url), accessToken }));
-  }
-
-  function workspaceApi(url: string, accessToken: string | undefined): WorkspaceResourceApi {
-    return new WorkspaceResourceApi(new Configuration({ basePath: basePath(url), accessToken }));
+  function workspaceApi(serviceUrl: string, accessToken: string | undefined): WorkspaceResourceApi {
+    return new WorkspaceResourceApi(new Configuration({ basePath: serviceUrl, accessToken }));
   }
 
   export async function ping(request: PingRequest, options: RequestOptions = {}): Promise<boolean> {

--- a/node/landing-page/package.json
+++ b/node/landing-page/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
+    "@types/node": "^16.18.6",
     "@vue/cli-plugin-babel": "~4.5.16",
     "@vue/cli-plugin-eslint": "~4.5.16",
     "@vue/cli-plugin-typescript": "~4.5.16",

--- a/node/landing-page/src/App.vue
+++ b/node/landing-page/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <img className='logo' alt="Theia logo" src="/logo.svg" />
+  <img className="logo" alt="Theia logo" :src="logo" />
   <SessionLauncher
     :serviceUrl="serviceUrl"
     :appDefinition="appDefinition"
@@ -21,6 +21,7 @@ interface AppData {
   email: string | undefined;
   token: string | undefined;
   workspaceName?: string;
+  logo: string;
 }
 
 export default defineComponent({
@@ -43,7 +44,9 @@ export default defineComponent({
     return {
       email: undefined,
       token: undefined,
-      workspaceName: undefined
+      workspaceName: undefined,
+      // https://cli.vuejs.org/guide/html-and-static-assets.html#the-public-folder
+      logo: process.env.BASE_URL + 'logo.svg'
     } as AppData;
   },
   created() {

--- a/node/landing-page/vue.config.js
+++ b/node/landing-page/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  publicPath: "./"
+}

--- a/node/landing-page/yarn.lock
+++ b/node/landing-page/yarn.lock
@@ -1177,6 +1177,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.15.tgz#20ae1ec80c57ee844b469f968a1cd511d4088b29"
   integrity sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==
 
+"@types/node@^16.18.6":
+  version "16.18.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.6.tgz#87846192fd51b693368fad3e99123169225621d4"
+  integrity sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"


### PR DESCRIPTION
- Configure the base url to be relative. With that the landing page can run on any path
- Improve variable names in common client and remove obsolete code

Note: Like the Try Now page, the landing page only works if the URL ends with a trailing `/`.

Fix #118

Contributed on behalf of STMicroelectronics

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>