### PR TITLE
Add node common API for metrics endpoints

### DIFF
--- a/doc/docs/openapi.json
+++ b/doc/docs/openapi.json
@@ -149,6 +149,49 @@
         } ]
       }
     },
+    "/service/session/performance/{appId}/{sessionName}" : {
+      "get" : {
+        "tags" : [ "Session Resource" ],
+        "summary" : "Get performance metrics",
+        "description" : "Returns the current CPU and memory usage of the session's pod.",
+        "parameters" : [ {
+          "name" : "appId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "sessionName",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SessionPerformance"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/service/session/{appId}/{user}" : {
       "get" : {
         "tags" : [ "Session Resource" ],
@@ -425,6 +468,44 @@
           },
           "user" : {
             "description" : "The user identification, usually the email address.",
+            "type" : "string"
+          }
+        }
+      },
+      "SessionPerformance" : {
+        "description" : "Description of the performance of a session",
+        "required" : [ "cpuAmount", "cpuFormat", "memoryAmount", "memoryFormat" ],
+        "type" : "object",
+        "properties" : {
+          "cpuAmount" : {
+            "description" : "Used CPU amount of the workspace",
+            "type" : "string"
+          },
+          "cpuFormat" : {
+            "description" : "Used CPU format of the workspace",
+            "type" : "string"
+          },
+          "memoryAmount" : {
+            "description" : "Used memory amount of the workspace",
+            "type" : "string"
+          },
+          "memoryFormat" : {
+            "description" : "Used memory format of the workspace",
+            "type" : "string"
+          }
+        }
+      },
+      "SessionPerformanceRequest" : {
+        "description" : "A request to list the sessions of a user.",
+        "required" : [ "appId", "sessionName" ],
+        "type" : "object",
+        "properties" : {
+          "appId" : {
+            "description" : "The App Id of this Theia.cloud instance. Request without a matching Id will be denied.",
+            "type" : "string"
+          },
+          "sessionName" : {
+            "description" : "The name of the session",
             "type" : "string"
           }
         }

--- a/node/common/src/client.ts
+++ b/node/common/src/client.ts
@@ -4,11 +4,11 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   LaunchRequest as ClientLaunchRequest,
   PingRequest as ClientPingRequest, RootResourceApi, SessionActivityRequest as ClientSessionActivityRequest, SessionListRequest as ClientSessionListRequest,
+  SessionPerformance, SessionPerformanceRequest as ClientSessionPerformanceRequest,
   SessionResourceApi, SessionSpec, SessionStartRequest as ClientSessionStartRequest, SessionStopRequest as ClientSessionStopRequest,
   UserWorkspace, WorkspaceCreationRequest as ClientWorkspaceCreationRequest,
   WorkspaceDeletionRequest as ClientWorkspaceDeletionRequest, WorkspaceListRequest as ClientWorkspaceListRequest,
-  WorkspaceResourceApi
-} from './client/api';
+  WorkspaceResourceApi } from './client/api';
 import { Configuration } from './client/configuration';
 
 export const DEFAULT_CALL_TIMEOUT = 30000;
@@ -79,6 +79,11 @@ export namespace SessionActivityRequest {
   export const KIND = 'sessionActivityRequest';
 }
 
+export type SessionPerformanceRequest = ClientSessionPerformanceRequest & ServiceRequest;
+export namespace SessionPerformanceRequest {
+  export const KIND = 'sessionPerformanceRequest';
+}
+
 export type WorkspaceListRequest = ClientWorkspaceListRequest & ServiceRequest;
 export namespace WorkspaceListRequest {
   export const KIND = 'workspaceListRequest';
@@ -147,6 +152,14 @@ export namespace TheiaCloud {
       const { accessToken, retries, timeout } = options;
       const sessionActivityRequest = { kind: SessionActivityRequest.KIND, ...request };
       return call(() => sessionApi(request.serviceUrl, accessToken).serviceSessionPatch(sessionActivityRequest, createConfig(timeout)), retries);
+    }
+
+    export async function getSessionPerformance(request: SessionPerformanceRequest, options: RequestOptions = {}): Promise<SessionPerformance> {
+      const { accessToken, retries, timeout } = options;
+      return call(
+        () => sessionApi(request.serviceUrl, accessToken).serviceSessionPerformanceAppIdSessionNameGet(request.appId, request.sessionName, createConfig(timeout)),
+        retries
+      );
     }
   }
 

--- a/node/common/src/client/api.ts
+++ b/node/common/src/client/api.ts
@@ -122,6 +122,56 @@ export interface SessionListRequest {
     'user': string;
 }
 /**
+ * Description of the performance of a session
+ * @export
+ * @interface SessionPerformance
+ */
+export interface SessionPerformance {
+    /**
+     * Used CPU amount of the workspace
+     * @type {string}
+     * @memberof SessionPerformance
+     */
+    'cpuAmount': string;
+    /**
+     * Used CPU format of the workspace
+     * @type {string}
+     * @memberof SessionPerformance
+     */
+    'cpuFormat': string;
+    /**
+     * Used memory amount of the workspace
+     * @type {string}
+     * @memberof SessionPerformance
+     */
+    'memoryAmount': string;
+    /**
+     * Used memory format of the workspace
+     * @type {string}
+     * @memberof SessionPerformance
+     */
+    'memoryFormat': string;
+}
+/**
+ * A request to list the sessions of a user.
+ * @export
+ * @interface SessionPerformanceRequest
+ */
+export interface SessionPerformanceRequest {
+    /**
+     * The App Id of this Theia.cloud instance. Request without a matching Id will be denied.
+     * @type {string}
+     * @memberof SessionPerformanceRequest
+     */
+    'appId': string;
+    /**
+     * The name of the session
+     * @type {string}
+     * @memberof SessionPerformanceRequest
+     */
+    'sessionName': string;
+}
+/**
  * 
  * @export
  * @interface SessionSpec
@@ -650,6 +700,48 @@ export const SessionResourceApiAxiosParamCreator = function (configuration?: Con
             };
         },
         /**
+         * Returns the current CPU and memory usage of the session\'s pod.
+         * @summary Get performance metrics
+         * @param {string} appId 
+         * @param {string} sessionName 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        serviceSessionPerformanceAppIdSessionNameGet: async (appId: string, sessionName: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'appId' is not null or undefined
+            assertParamExists('serviceSessionPerformanceAppIdSessionNameGet', 'appId', appId)
+            // verify required parameter 'sessionName' is not null or undefined
+            assertParamExists('serviceSessionPerformanceAppIdSessionNameGet', 'sessionName', sessionName)
+            const localVarPath = `/service/session/performance/{appId}/{sessionName}`
+                .replace(`{${"appId"}}`, encodeURIComponent(String(appId)))
+                .replace(`{${"sessionName"}}`, encodeURIComponent(String(sessionName)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication SecurityScheme required
+            // oauth required
+            await setOAuthToObject(localVarHeaderParameter, "SecurityScheme", [], configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Starts a new session for an existing workspace and responds with the URL of the started session.
          * @summary Start a new session
          * @param {SessionStartRequest} [sessionStartRequest] 
@@ -732,6 +824,18 @@ export const SessionResourceApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * Returns the current CPU and memory usage of the session\'s pod.
+         * @summary Get performance metrics
+         * @param {string} appId 
+         * @param {string} sessionName 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async serviceSessionPerformanceAppIdSessionNameGet(appId: string, sessionName: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<SessionPerformance>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.serviceSessionPerformanceAppIdSessionNameGet(appId, sessionName, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * Starts a new session for an existing workspace and responds with the URL of the started session.
          * @summary Start a new session
          * @param {SessionStartRequest} [sessionStartRequest] 
@@ -782,6 +886,17 @@ export const SessionResourceApiFactory = function (configuration?: Configuration
          */
         serviceSessionPatch(sessionActivityRequest?: SessionActivityRequest, options?: any): AxiosPromise<boolean> {
             return localVarFp.serviceSessionPatch(sessionActivityRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Returns the current CPU and memory usage of the session\'s pod.
+         * @summary Get performance metrics
+         * @param {string} appId 
+         * @param {string} sessionName 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        serviceSessionPerformanceAppIdSessionNameGet(appId: string, sessionName: string, options?: any): AxiosPromise<SessionPerformance> {
+            return localVarFp.serviceSessionPerformanceAppIdSessionNameGet(appId, sessionName, options).then((request) => request(axios, basePath));
         },
         /**
          * Starts a new session for an existing workspace and responds with the URL of the started session.
@@ -838,6 +953,19 @@ export class SessionResourceApi extends BaseAPI {
      */
     public serviceSessionPatch(sessionActivityRequest?: SessionActivityRequest, options?: AxiosRequestConfig) {
         return SessionResourceApiFp(this.configuration).serviceSessionPatch(sessionActivityRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Returns the current CPU and memory usage of the session\'s pod.
+     * @summary Get performance metrics
+     * @param {string} appId 
+     * @param {string} sessionName 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof SessionResourceApi
+     */
+    public serviceSessionPerformanceAppIdSessionNameGet(appId: string, sessionName: string, options?: AxiosRequestConfig) {
+        return SessionResourceApiFp(this.configuration).serviceSessionPerformanceAppIdSessionNameGet(appId, sessionName, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/node/common/src/client/common.ts
+++ b/node/common/src/client/common.ts
@@ -142,7 +142,7 @@ export const toPathString = function (url: URL) {
  */
 export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
     return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-        const axiosRequestArgs = {...axiosArgs.options, url: (configuration ? configuration.basePath : basePath) + axiosArgs.url};
+        const axiosRequestArgs = {...axiosArgs.options, url: (configuration?.basePath || basePath) + axiosArgs.url};
         return axios.request<T, R>(axiosRequestArgs);
     };
 }


### PR DESCRIPTION
Regenerate the OpenAPI specification and based on this the service's typescript API.

Contributed on behalf of STMicroelectronics and CEA

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>