### PR TITLE
Adapt service role to remove write access on pods

### DIFF
--- a/helm/theia.cloud/templates/service-role.yaml
+++ b/helm/theia.cloud/templates/service-role.yaml
@@ -8,13 +8,18 @@ rules:
     apiGroups:
       - ""
       - theia.cloud
-      - metrics.k8s.io
     resources:
       - appdefinitions
       - sessions
       - workspaces
-      - pods
     verbs: ["list", "create", "watch", "get", "patch", "delete"]
+  -
+    apiGroups:
+      - ""
+      - metrics.k8s.io
+    resources:
+      - pods
+    verbs: ["list", "get", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Split the rules for custom resource and metrics access. Now, the service can no longer create, modify or delete pods.

Fixes #120

Contributed on behalf of STMicroelectronics and CEA

Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>