### PR TITLE
Fix ingresses to handle missing trailing slashes

### DIFF
--- a/helm/theia.cloud/templates/landing-page-ingress.yaml
+++ b/helm/theia.cloud/templates/landing-page-ingress.yaml
@@ -9,6 +9,10 @@ metadata:
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # Rewrite all URLs not ending with a segment containing . or ? with a trailing slash
+    # This is necessary to correctly resolve relative paths (e.g. for css files) from the landing page.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^([^.?]*[^/])$ $1/ redirect;
     {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/node/try-now-page/src/App.tsx
+++ b/node/try-now-page/src/App.tsx
@@ -37,8 +37,8 @@ function App(): JSX.Element {
       initialised = true;
       const element = document.getElementById('selectapp');
       const urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.has('appDef')) {
-        const defaultSelection = urlParams.get('appDef');
+      if (urlParams.has('appDef') || urlParams.has('appdef')) {
+        const defaultSelection = urlParams.get('appDef') || urlParams.get('appdef');
         // eslint-disable-next-line no-null/no-null
         if (defaultSelection !== null && isDefaultSelectionValueValid(defaultSelection, config.appDefinition, config.additionalApps)) {
           // eslint-disable-next-line no-null/no-null


### PR DESCRIPTION
- Fix landing page ingress to work for paths without trailing slash
- ~Fix workspace ingress to work direct links without trailing slash~ -> Removed because current version results in redirect loop whe using keycloak
- Make Try Now page's `appDef` URL parameter case insensitive

Contributed on behalf of STMicroelectronics and CEA