### PR TITLE
Storage class and amount configuration for workspace volumes

### DIFF
--- a/helm/theia.cloud/valuesGKETryNow.yaml
+++ b/helm/theia.cloud/valuesGKETryNow.yaml
@@ -41,7 +41,6 @@ keycloak:
 
 operator:
   eagerStart: false
-  cloudProvider: "GKE"
   bandwidthLimiter: "WONDERSHAPER"
   sessionsPerUser: "1"
 

--- a/helm/theia.cloud/valuesMinikube.yaml
+++ b/helm/theia.cloud/valuesMinikube.yaml
@@ -34,6 +34,7 @@ keycloak:
   cookieSecret: "OQINaROshtE9TcZkNAm5Zs2Pv3xaWytBmc5W7sPX7ws="
 
 operator:
+  cloudProvider: MINIKUBE
   imagePullPolicy: Always
 
 service:

--- a/helm/theia.cloud/valuesTestLandingPage.yaml
+++ b/helm/theia.cloud/valuesTestLandingPage.yaml
@@ -30,6 +30,7 @@ keycloak:
   cookieSecret: "OQINaROshtE9TcZkNAm5Zs2Pv3xaWytBmc5W7sPX7ws="
 
 operator:
+  cloudProvider: MINIKUBE
   imagePullPolicy: Always
 
 service:

--- a/helm/theia.cloud/valuesTestTrynowPage.yaml
+++ b/helm/theia.cloud/valuesTestTrynowPage.yaml
@@ -28,6 +28,7 @@ keycloak:
   enable: false
 
 operator:
+  cloudProvider: MINIKUBE
   imagePullPolicy: Always
 
 service:

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -21,7 +21,7 @@ import picocli.CommandLine.Option;
 public class TheiaCloudArguments {
 
     public enum CloudProvider {
-	K8S, GKE
+	K8S, MINIKUBE
     }
 
     public enum BandwidthLimiter {
@@ -73,6 +73,14 @@ public class TheiaCloudArguments {
 
     @Option(names = { "--instancesPath" }, description = "Subpath instances are hosted at", required = false)
     private String instancesPath;
+
+    @Option(names = {
+	    "--storageClassName" }, description = "K8s storage class to use for persistent workspace volume claims.", required = false)
+    private String storageClassName;
+
+    @Option(names = {
+	    "--requestedStorage" }, description = "Amount of storage requested for persistent workspace volume claims.", required = false)
+    private String requestedStorage;
 
     public boolean isUseKeycloak() {
 	return useKeycloak;
@@ -126,6 +134,14 @@ public class TheiaCloudArguments {
 	return instancesPath;
     }
 
+    public String getStorageClassName() {
+	return storageClassName;
+    }
+
+    public String getRequestedStorage() {
+	return requestedStorage;
+    }
+
     @Override
     public int hashCode() {
 	final int prime = 31;
@@ -134,12 +150,14 @@ public class TheiaCloudArguments {
 	result = prime * result + ((bandwidthLimiter == null) ? 0 : bandwidthLimiter.hashCode());
 	result = prime * result + ((cloudProvider == null) ? 0 : cloudProvider.hashCode());
 	result = prime * result + (eagerStart ? 1231 : 1237);
-	result = prime * result + ((instancesPath == null) ? 0 : instancesPath.hashCode());
-	result = prime * result + (enableMonitor ? 1231 : 1237);
 	result = prime * result + (enableActivityTracker ? 1231 : 1237);
+	result = prime * result + (enableMonitor ? 1231 : 1237);
+	result = prime * result + ((instancesPath == null) ? 0 : instancesPath.hashCode());
+	result = prime * result + ((monitorInterval == null) ? 0 : monitorInterval.hashCode());
+	result = prime * result + ((requestedStorage == null) ? 0 : requestedStorage.hashCode());
 	result = prime * result + ((serviceUrl == null) ? 0 : serviceUrl.hashCode());
 	result = prime * result + ((sessionsPerUser == null) ? 0 : sessionsPerUser.hashCode());
-	result = prime * result + ((monitorInterval == null) ? 0 : monitorInterval.hashCode());
+	result = prime * result + ((storageClassName == null) ? 0 : storageClassName.hashCode());
 	result = prime * result + (useKeycloak ? 1231 : 1237);
 	result = prime * result + (usePaths ? 1231 : 1237);
 	result = prime * result + ((wondershaperImage == null) ? 0 : wondershaperImage.hashCode());
@@ -166,13 +184,24 @@ public class TheiaCloudArguments {
 	    return false;
 	if (eagerStart != other.eagerStart)
 	    return false;
+	if (enableActivityTracker != other.enableActivityTracker)
+	    return false;
+	if (enableMonitor != other.enableMonitor)
+	    return false;
 	if (instancesPath == null) {
 	    if (other.instancesPath != null)
 		return false;
 	} else if (!instancesPath.equals(other.instancesPath))
-	if (enableMonitor != other.enableMonitor)
 	    return false;
-	if (enableActivityTracker != other.enableActivityTracker)
+	if (monitorInterval == null) {
+	    if (other.monitorInterval != null)
+		return false;
+	} else if (!monitorInterval.equals(other.monitorInterval))
+	    return false;
+	if (requestedStorage == null) {
+	    if (other.requestedStorage != null)
+		return false;
+	} else if (!requestedStorage.equals(other.requestedStorage))
 	    return false;
 	if (serviceUrl == null) {
 	    if (other.serviceUrl != null)
@@ -184,10 +213,10 @@ public class TheiaCloudArguments {
 		return false;
 	} else if (!sessionsPerUser.equals(other.sessionsPerUser))
 	    return false;
-	if (monitorInterval == null) {
-	    if (other.monitorInterval != null)
+	if (storageClassName == null) {
+	    if (other.storageClassName != null)
 		return false;
-	} else if (!monitorInterval.equals(other.monitorInterval))
+	} else if (!storageClassName.equals(other.storageClassName))
 	    return false;
 	if (useKeycloak != other.useKeycloak)
 	    return false;
@@ -203,11 +232,12 @@ public class TheiaCloudArguments {
 
     @Override
     public String toString() {
-	return "TheiaCloudArguments [useKeycloak=" + useKeycloak + ", eagerStart=" + eagerStart + ", cloudProvider="
-		+ cloudProvider + ", bandwidthLimiter=" + bandwidthLimiter + ", wondershaperImage=" + wondershaperImage
-		+ ", serviceUrl=" + serviceUrl + ", sessionsPerUser=" + sessionsPerUser + ", appId=" + appId
-		+ ", usePaths=" + usePaths + ", instancesPath=" + instancesPath + ", enableMonitor=" + enableMonitor
-		+ ", enableActivityTracker=" + enableActivityTracker + ", monitorInterval=" + monitorInterval + "]";
+	return "TheiaCloudArguments [useKeycloak=" + useKeycloak + ", eagerStart=" + eagerStart + ", enableMonitor="
+		+ enableMonitor + ", enableActivityTracker=" + enableActivityTracker + ", monitorInterval="
+		+ monitorInterval + ", cloudProvider=" + cloudProvider + ", bandwidthLimiter=" + bandwidthLimiter
+		+ ", wondershaperImage=" + wondershaperImage + ", serviceUrl=" + serviceUrl + ", sessionsPerUser="
+		+ sessionsPerUser + ", appId=" + appId + ", usePaths=" + usePaths + ", instancesPath=" + instancesPath
+		+ ", storageClassName=" + storageClassName + ", requestedStorage=" + requestedStorage + "]";
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/di/AbstractTheiaCloudOperatorModule.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/di/AbstractTheiaCloudOperatorModule.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -31,12 +31,14 @@ import org.eclipse.theia.cloud.operator.handler.BandwidthLimiter;
 import org.eclipse.theia.cloud.operator.handler.DeploymentTemplateReplacements;
 import org.eclipse.theia.cloud.operator.handler.IngressPathProvider;
 import org.eclipse.theia.cloud.operator.handler.PersistentVolumeCreator;
+import org.eclipse.theia.cloud.operator.handler.PersistentVolumeTemplateReplacements;
 import org.eclipse.theia.cloud.operator.handler.SessionHandler;
 import org.eclipse.theia.cloud.operator.handler.TimeoutStrategy;
 import org.eclipse.theia.cloud.operator.handler.WorkspaceHandler;
 import org.eclipse.theia.cloud.operator.handler.impl.BandwidthLimiterImpl;
 import org.eclipse.theia.cloud.operator.handler.impl.DefaultDeploymentTemplateReplacements;
 import org.eclipse.theia.cloud.operator.handler.impl.DefaultPersistentVolumeCreator;
+import org.eclipse.theia.cloud.operator.handler.impl.DefaultPersistentVolumeTemplateReplacements;
 import org.eclipse.theia.cloud.operator.handler.impl.IngressPathProviderImpl;
 import org.eclipse.theia.cloud.operator.monitor.MonitorActivityTracker;
 import org.eclipse.theia.cloud.operator.monitor.MonitorActivityTrackerImpl;
@@ -58,6 +60,8 @@ public abstract class AbstractTheiaCloudOperatorModule extends AbstractModule {
 	bind(PersistentVolumeCreator.class).to(bindPersistentVolumeHandler()).in(Singleton.class);
 	bind(IngressPathProvider.class).to(bindIngressPathProvider()).in(Singleton.class);
 	bind(DeploymentTemplateReplacements.class).to(bindDeploymentTemplateReplacements()).in(Singleton.class);
+	bind(PersistentVolumeTemplateReplacements.class).to(bindPersistentVolumeTemplateReplacements())
+		.in(Singleton.class);
 
 	bind(AppDefinitionHandler.class).to(bindAppDefinitionHandler()).in(Singleton.class);
 	bind(SessionHandler.class).to(bindSessionHandler()).in(Singleton.class);
@@ -100,6 +104,10 @@ public abstract class AbstractTheiaCloudOperatorModule extends AbstractModule {
 
     protected Class<? extends MonitorMessagingService> bindMonitorMessagingService() {
 	return MonitorMessagingServiceImpl.class;
+    }
+
+    protected Class<? extends PersistentVolumeTemplateReplacements> bindPersistentVolumeTemplateReplacements() {
+	return DefaultPersistentVolumeTemplateReplacements.class;
     }
 
     protected abstract Class<? extends WorkspaceHandler> bindWorkspaceHandler();

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/di/DefaultTheiaCloudOperatorModule.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/di/DefaultTheiaCloudOperatorModule.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -23,10 +23,10 @@ import org.eclipse.theia.cloud.operator.handler.SessionHandler;
 import org.eclipse.theia.cloud.operator.handler.WorkspaceHandler;
 import org.eclipse.theia.cloud.operator.handler.impl.EagerStartAppDefinitionAddedHandler;
 import org.eclipse.theia.cloud.operator.handler.impl.EagerStartSessionHandler;
-import org.eclipse.theia.cloud.operator.handler.impl.GKEPersistentVolumeCreator;
 import org.eclipse.theia.cloud.operator.handler.impl.LazySessionHandler;
 import org.eclipse.theia.cloud.operator.handler.impl.LazyStartAppDefinitionHandler;
 import org.eclipse.theia.cloud.operator.handler.impl.LazyWorkspaceHandler;
+import org.eclipse.theia.cloud.operator.handler.impl.MinikubePersistentVolumeCreator;
 
 public class DefaultTheiaCloudOperatorModule extends AbstractTheiaCloudOperatorModule {
 
@@ -45,8 +45,8 @@ public class DefaultTheiaCloudOperatorModule extends AbstractTheiaCloudOperatorM
     @Override
     protected Class<? extends PersistentVolumeCreator> bindPersistentVolumeHandler() {
 	switch (arguments.getCloudProvider()) {
-	case GKE:
-	    return GKEPersistentVolumeCreator.class;
+	case MINIKUBE:
+	    return MinikubePersistentVolumeCreator.class;
 	case K8S:
 	default:
 	    return super.bindPersistentVolumeHandler();

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/PersistentVolumeTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/PersistentVolumeTemplateReplacements.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource and others.
+ * Copyright (C) 2023 EclipseSource, STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,11 +17,11 @@ package org.eclipse.theia.cloud.operator.handler;
 
 import java.util.Map;
 
-import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
-import org.eclipse.theia.cloud.common.k8s.resource.Session;
+import org.eclipse.theia.cloud.common.k8s.resource.Workspace;
 
-public interface DeploymentTemplateReplacements extends TemplateReplacements {
-    Map<String, String> getReplacements(String namespace, AppDefinition appDefinition, int instance);
+public interface PersistentVolumeTemplateReplacements extends TemplateReplacements {
 
-    Map<String, String> getReplacements(String namespace, AppDefinition appDefinition, Session session);
+    Map<String, String> getPersistentVolumeReplacements(String namespace, Workspace workspace);
+
+    Map<String, String> getPersistentVolumeClaimReplacements(String namespace, Workspace workspace);
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/TemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/TemplateReplacements.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource and others.
+ * Copyright (C) 2023 EclipseSource, STMicroelectronics and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,13 +15,12 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.operator.handler;
 
-import java.util.Map;
+public interface TemplateReplacements {
+    default String orEmpty(String string) {
+	return string == null ? "" : string;
+    }
 
-import org.eclipse.theia.cloud.common.k8s.resource.AppDefinition;
-import org.eclipse.theia.cloud.common.k8s.resource.Session;
-
-public interface DeploymentTemplateReplacements extends TemplateReplacements {
-    Map<String, String> getReplacements(String namespace, AppDefinition appDefinition, int instance);
-
-    Map<String, String> getReplacements(String namespace, AppDefinition appDefinition, Session session);
+    default String orDefault(String string, String defaultValue) {
+	return string == null ? defaultValue : string;
+    }
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultPersistentVolumeCreator.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultPersistentVolumeCreator.java
@@ -44,7 +44,6 @@ public class DefaultPersistentVolumeCreator implements PersistentVolumeCreator {
 
     private static final Logger LOGGER = LogManager.getLogger(DefaultPersistentVolumeCreator.class);
 
-    protected static final int THEIA_CONTAINER_INDEX = 1;
 
     protected static final String TEMPLATE_PERSISTENTVOLUMECLAIM_YAML = "/templatePersistentVolumeClaim.yaml";
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultPersistentVolumeTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultPersistentVolumeTemplateReplacements.java
@@ -1,0 +1,64 @@
+/********************************************************************************
+ * Copyright (C) 2023 EclipseSource, STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.operator.handler.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.theia.cloud.common.k8s.resource.Workspace;
+import org.eclipse.theia.cloud.common.util.WorkspaceUtil;
+import org.eclipse.theia.cloud.operator.TheiaCloudArguments;
+import org.eclipse.theia.cloud.operator.handler.PersistentVolumeTemplateReplacements;
+import org.eclipse.theia.cloud.operator.handler.util.TheiaCloudHandlerUtil;
+
+import com.google.inject.Inject;
+
+public class DefaultPersistentVolumeTemplateReplacements implements PersistentVolumeTemplateReplacements {
+
+    public static final String PLACEHOLDER_PERSISTENTVOLUMENAME = "placeholder-pv";
+    public static final String PLACEHOLDER_LABEL_WORKSPACE_NAME = "placeholder-label-workspace-name";
+    public static final String PLACEHOLDER_STORAGE_CLASS_NAME = "placeholder-storage-class-name";
+    public static final String PLACEHOLDER_REQUESTED_STORAGE = "placeholder-requested-storage";
+
+    public static final String DEFAULT_REQUESTED_STORAGE = "250Mi";
+
+    @Inject
+    TheiaCloudArguments arguments;
+
+    @Override
+    public Map<String, String> getPersistentVolumeReplacements(String namespace, Workspace workspace) {
+	Map<String, String> replacements = new LinkedHashMap<String, String>();
+	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace));
+	replacements.put(TheiaCloudHandlerUtil.PLACEHOLDER_NAMESPACE, namespace);
+	replacements.put(PLACEHOLDER_LABEL_WORKSPACE_NAME, workspace.getSpec().getName());
+	replacements.put(PLACEHOLDER_REQUESTED_STORAGE,
+		orDefault(arguments.getRequestedStorage(), DEFAULT_REQUESTED_STORAGE));
+	return replacements;
+    }
+
+    @Override
+    public Map<String, String> getPersistentVolumeClaimReplacements(String namespace, Workspace workspace) {
+	Map<String, String> replacements = new LinkedHashMap<String, String>();
+	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace));
+	replacements.put(TheiaCloudHandlerUtil.PLACEHOLDER_NAMESPACE, namespace);
+	replacements.put(PLACEHOLDER_LABEL_WORKSPACE_NAME, workspace.getSpec().getName());
+	replacements.put(PLACEHOLDER_STORAGE_CLASS_NAME, orEmpty(arguments.getStorageClassName()));
+	replacements.put(PLACEHOLDER_REQUESTED_STORAGE,
+		orDefault(arguments.getRequestedStorage(), DEFAULT_REQUESTED_STORAGE));
+	return replacements;
+    }
+
+}

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudPersistentVolumeUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudPersistentVolumeUtil.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -16,21 +16,12 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.operator.handler.util;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.eclipse.theia.cloud.common.k8s.resource.AppDefinitionSpec;
-import org.eclipse.theia.cloud.common.k8s.resource.Workspace;
-import org.eclipse.theia.cloud.common.util.WorkspaceUtil;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PodSpec;
 
 public final class TheiaCloudPersistentVolumeUtil {
-
-    public static final String PLACEHOLDER_PERSISTENTVOLUMENAME = "placeholder-pv";
-    public static final String PLACEHOLDER_LABEL_WORKSPACE_NAME = "placeholder-label-workspace-name";
-
     private static final String MOUNT_PATH = "/home/project/persisted";
 
     private TheiaCloudPersistentVolumeUtil() {
@@ -43,22 +34,6 @@ public final class TheiaCloudPersistentVolumeUtil {
 	    return MOUNT_PATH;
 	}
 	return mountPath;
-    }
-
-    public static Map<String, String> getPersistentVolumeReplacements(String namespace, Workspace workspace) {
-	Map<String, String> replacements = new LinkedHashMap<String, String>();
-	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace));
-	replacements.put(TheiaCloudHandlerUtil.PLACEHOLDER_NAMESPACE, namespace);
-	replacements.put(PLACEHOLDER_LABEL_WORKSPACE_NAME, workspace.getSpec().getName());
-	return replacements;
-    }
-
-    public static Map<String, String> getPersistentVolumeClaimReplacements(String namespace, Workspace workspace) {
-	Map<String, String> replacements = new LinkedHashMap<String, String>();
-	replacements.put(PLACEHOLDER_PERSISTENTVOLUMENAME, WorkspaceUtil.getStorageName(workspace));
-	replacements.put(TheiaCloudHandlerUtil.PLACEHOLDER_NAMESPACE, namespace);
-	replacements.put(PLACEHOLDER_LABEL_WORKSPACE_NAME, workspace.getSpec().getName());
-	return replacements;
     }
 
     public static Container getTheiaContainer(PodSpec podSpec, AppDefinitionSpec appDefinition) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templatePersistentVolumeClaim.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templatePersistentVolumeClaim.yaml
@@ -8,8 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: ""
-  volumeName: placeholder-pv  
+  storageClassName: placeholder-storage-class-name
   resources:
     requests:
-      storage: 250Mi
+      storage: placeholder-requested-storage

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templatePersistentVolumeClaimMinikube.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templatePersistentVolumeClaimMinikube.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: ""
+  volumeName: placeholder-pv  
   resources:
     requests:
-      storage: 250Mi
+      storage: placeholder-requested-storage

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templatePersistentVolumeMinikube.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templatePersistentVolumeMinikube.yaml
@@ -7,6 +7,6 @@ spec:
   accessModes:
     - ReadWriteOnce
   capacity:
-    storage: 250Mi
+    storage: placeholder-requested-storage
   hostPath:
     path: /tmp/hostpath-provisioner/theia-cloud/placeholder-pv/


### PR DESCRIPTION
This changes the default persistent volume creation to use a storage class. Before, this was only done when configuring the GKE cloud provider. Now, the K8S cloud provider behaves this way and an additional cloud provider MINIKUBE was added to use the former behavior of the K8S provider. With this, the GKE cloud provider is obsolete and was deleted.

In addition, the used storage class and the amount of requested storage can now be configured via helm values.

- Add arguments `--storageClassName` and `--requestedStorage` to the operator
- Make persistent storage claiming via storage class the default
- Use the former default - explicitly creating the persistent volume - for new cloud provider MINIKUBE only
- Delete cloud provider GKE
- Rename files to fit the new default and cloud provider
- Adapt values files
- Extract persistent volume template replacements to injectable class and bind it in the theia cloud DI module.
- Create reusable TemplateReplacements interface

Part of #92

Contributed on behalf of STMicroelectronics

---

The Minikube part can be tested locally. Simply checkout the corresponding branch of the helm repository (see PR https://github.com/eclipsesource/theia-cloud-helm/pull/12) and use the `helm/theia.cloud/valuesMinikube.yaml` file from this repository.
In addition:
- set ephemeral storage to false and set `operator.requestedStorage` to some value (e.g. 100Mi).
- Build the operator from this branch and configure it in the values
- Launch a new session and verify that the created persistent volume (pv) and persistent volume claim (pcv) each request the configured storage.

Testing the K8S config might be a bit harder. As it's just a replacement more, maybe it is enough to carefully review that part of the code for now (template and replacements)