### PR TITLE
trynow: Show login button instead of launch button while logged out

### DIFF
--- a/node/try-now-page/src/App.tsx
+++ b/node/try-now-page/src/App.tsx
@@ -207,7 +207,7 @@ function App(): JSX.Element {
                     />
                 }
               </p>
-              <TermsAndConditions accepted={acceptedTerms} onTermsAccepted={setAcceptedTerms} />
+              { !needsLogin && <TermsAndConditions accepted={acceptedTerms} onTermsAccepted={setAcceptedTerms} /> }
             </div>
           </div>
         )}

--- a/node/try-now-page/src/App.tsx
+++ b/node/try-now-page/src/App.tsx
@@ -5,12 +5,15 @@ import { AppDefinition, getTheiaCloudConfig, LaunchRequest, PingRequest, TheiaCl
 import Keycloak, { KeycloakConfig } from 'keycloak-js';
 import { useEffect, useState } from 'react';
 
+import { AppLogo } from './components/AppLogo';
 import { ErrorComponent } from './components/ErrorComponent';
 import { Footer } from './components/Footer';
 import { Header } from './components/Header';
 import { LaunchApp } from './components/LaunchApp';
 import { Loading } from './components/Loading';
+import { LoginButton } from './components/LoginButton';
 import { LoginInfo } from './components/LoginInfo';
+import { TermsAndConditions } from './components/TermsAndConditions';
 
 // global state to be kept between render calls
 let initialized = false;
@@ -36,13 +39,13 @@ function App(): JSX.Element {
     initialAppDefinition = config.appDefinition;
   }
 
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [selectedAppName, setSelectedAppName] = useState(initialAppName);
   const [selectedAppDefinition, setSelectedAppDefinition] = useState(initialAppDefinition);
 
   const [email, setEmail] = useState<string>();
   const [token, setToken] = useState<string>();
   const [logoutUrl, setLogoutUrl] = useState<string>();
-  const [showLoginInformation, setShowLoginInformation] = useState<boolean>(false);
 
   useEffect(() => {
     if (!initialized) {
@@ -105,10 +108,6 @@ function App(): JSX.Element {
       }
     }
   }, []);
-
-  useEffect(() => {
-    token ? setShowLoginInformation(false) : setShowLoginInformation(true);
-  }, [token]);
 
   document.title = `${selectedAppName} - Try Now`;
 
@@ -180,6 +179,8 @@ function App(): JSX.Element {
       });
   };
 
+  const needsLogin = config.useKeycloak && !token;
+
   return (
     <div className='App'>
       {config.useKeycloak ? (
@@ -192,19 +193,27 @@ function App(): JSX.Element {
           <Loading />
         ) : (
           <div>
-            <LaunchApp
-              appName={selectedAppName}
-              appDefinition={selectedAppDefinition}
-              onStartSession={handleStartSession}
-              token={token}
-              config={config}
-            />
+            <div>
+              <AppLogo />
+              <p>
+                {
+                  needsLogin
+                    ? <LoginButton login={authenticate} />
+                    : <LaunchApp
+                      acceptedTerms={acceptedTerms}
+                      appName={selectedAppName}
+                      appDefinition={selectedAppDefinition}
+                      onStartSession={handleStartSession}
+                    />
+                }
+              </p>
+              <TermsAndConditions accepted={acceptedTerms} onTermsAccepted={setAcceptedTerms} />
+            </div>
           </div>
         )}
         <ErrorComponent message={error} />
         {
-          // eslint-disable-next-line no-null/no-null
-          config.useKeycloak ? <LoginInfo showLoginInformation={showLoginInformation} /> : null
+          needsLogin && <LoginInfo />
         }
         <Footer
           config={config}

--- a/node/try-now-page/src/components/ErrorComponent.tsx
+++ b/node/try-now-page/src/components/ErrorComponent.tsx
@@ -11,4 +11,4 @@ export const ErrorComponent: React.FC<ErrorComponentProps> = ({ message }: Error
       <pre>ERROR: {message}</pre>
     </div>
   ) : // eslint-disable-next-line no-null/no-null
-  null;
+    null;

--- a/node/try-now-page/src/components/LaunchApp.tsx
+++ b/node/try-now-page/src/components/LaunchApp.tsx
@@ -1,58 +1,21 @@
-import { useState } from 'react';
-
-import { AppLogo } from './AppLogo';
-
 interface LaunchAppProps {
+  acceptedTerms: boolean;
   appName: string;
   appDefinition: string;
   onStartSession: (appDefinition: string) => void;
-  token: string | undefined;
-  config: any;
 }
 export const LaunchApp: React.FC<LaunchAppProps> = ({
+  acceptedTerms,
   appName,
   appDefinition,
-  onStartSession,
-  token,
-  config
-}: LaunchAppProps) => {
-  const [acceptedTerms, setAcceptedTerms] = useState(false);
-  return (
-    <div>
-      <AppLogo />
-      <p>
-        <button
-          className='App__try-now-button'
-          disabled={!acceptedTerms || (config.useKeycloak && !token)}
-          onClick={() => onStartSession(appDefinition)}
-        >
-          Launch {appName} &nbsp;&nbsp;&rarr;
-        </button>
-      </p>
-      <TermsAndConditions accepted={acceptedTerms} onTermsAccepted={setAcceptedTerms} />
-    </div>
-  );
-};
-
-interface TermsAndConditionsProps {
-  accepted: boolean;
-  onTermsAccepted: (accepted: boolean) => void;
-}
-const openTerms = (): boolean => {
-  window.open('./terms.html', 'popup', 'width=600,height=600');
-  return false;
-};
-const TermsAndConditions: React.FC<TermsAndConditionsProps> = ({
-  accepted,
-  onTermsAccepted
-}: TermsAndConditionsProps) => (
-  <div className='terms-and-conditions'>
-    <input id='accept-terms' type='checkbox' checked={accepted} onChange={ev => onTermsAccepted(ev.target.checked)} />
-    <label htmlFor='accept-terms'>
-      I accept the{' '}
-      <a target='popup' href='./terms.html' onClick={openTerms}>
-        terms and conditions.
-      </a>
-    </label>
-  </div>
+  onStartSession
+}: LaunchAppProps) => (
+  <button
+    className='App__try-now-button'
+    disabled={!acceptedTerms}
+    onClick={() => onStartSession(appDefinition)}
+  >
+    Launch {appName} &nbsp;&nbsp;&rarr;
+  </button>
 );
+

--- a/node/try-now-page/src/components/LoginButton.tsx
+++ b/node/try-now-page/src/components/LoginButton.tsx
@@ -1,0 +1,9 @@
+export interface LoginButtonProps {
+  login: () => void;
+}
+export const LoginButton: React.FC<LoginButtonProps> = ({login}: LoginButtonProps) => (<button
+  className='App__try-now-button'
+  onClick={() => login()}
+>
+    Login
+</button>);

--- a/node/try-now-page/src/components/LoginInfo.tsx
+++ b/node/try-now-page/src/components/LoginInfo.tsx
@@ -1,21 +1,14 @@
-interface LoginInfoProps {
-  showLoginInformation: boolean;
-}
-
-export const LoginInfo: React.FC<LoginInfoProps> = ({ showLoginInformation }: LoginInfoProps) =>
-  showLoginInformation ? (
-    <div className='App__info-message'>
-      <h2>
-        <strong>Please login to use this demo</strong>
-      </h2>
-      <pre>
-        We do only need your login in data for technical reasons (e.g. avoiding crypto-mining or other harmful actions).
-      </pre>
-      <pre>We will not contact you via your e-mail or use it for any other marketing purposes.</pre>{' '}
-      <pre>
-        You can login using your Github account and do so on the top right of the page (You will be forwarded to our
-        keycloak instance).
-      </pre>
-    </div>
-  ) : // eslint-disable-next-line no-null/no-null
-  null;
+export const LoginInfo: React.FC = () => (
+  <div className='App__info-message'>
+    <h2>
+      <strong>Please login to use this demo</strong>
+    </h2>
+    <pre>
+        We only need your login data for technical reasons (e.g. avoiding crypto-mining or other harmful actions).
+    </pre>
+    <pre>We will not contact you via your e-mail or use it for any other marketing purposes.</pre>{' '}
+    <pre>
+        You can login using your Github account (You will be forwarded to our Keycloak instance).
+    </pre>
+  </div>
+);

--- a/node/try-now-page/src/components/TermsAndConditions.tsx
+++ b/node/try-now-page/src/components/TermsAndConditions.tsx
@@ -1,0 +1,22 @@
+export interface TermsAndConditionsProps {
+  accepted: boolean;
+  onTermsAccepted: (accepted: boolean) => void;
+}
+const openTerms = (): boolean => {
+  window.open('./terms.html', 'popup', 'width=600,height=600');
+  return false;
+};
+export const TermsAndConditions: React.FC<TermsAndConditionsProps> = ({
+  accepted,
+  onTermsAccepted
+}: TermsAndConditionsProps) => (
+  <div className='terms-and-conditions'>
+    <input id='accept-terms' type='checkbox' checked={accepted} onChange={ev => onTermsAccepted(ev.target.checked)} />
+    <label htmlFor='accept-terms'>
+      I accept the{' '}
+      <a target='popup' href='./terms.html' onClick={openTerms}>
+        terms and conditions.
+      </a>
+    </label>
+  </div>
+);


### PR DESCRIPTION
- Refactor terms and conditions into a separate component
- Add login button component
- Simplify launch app component
- Simplify calculation of the need to show login button and information
- Fixed wording of the login info

Contributed on behalf of STMicroelectronics