### PR TITLE
Support zero max instances for app definitions

### DIFF
--- a/dockerfiles/operator/Dockerfile
+++ b/dockerfiles/operator/Dockerfile
@@ -3,11 +3,11 @@ WORKDIR /operator
 COPY java/common ./common
 COPY java/operator ./operator
 RUN cd /operator/common/maven-conf && \
-    mvn clean install && \
+    mvn clean install --no-transfer-progress && \
     cd /operator/common/org.eclipse.theia.cloud.common && \
-    mvn clean install && \
+    mvn clean install --no-transfer-progress && \
     cd /operator/operator/org.eclipse.theia.cloud.operator && \
-    mvn clean verify
+    mvn clean verify --no-transfer-progress
 
 FROM openjdk:11-jre-slim-buster
 RUN mkdir /templates

--- a/dockerfiles/service/Dockerfile
+++ b/dockerfiles/service/Dockerfile
@@ -3,11 +3,11 @@ WORKDIR /service
 COPY java/common ./common
 COPY java/service ./service
 RUN cd /service/common/maven-conf && \
-    mvn clean install && \
+    mvn clean install --no-transfer-progress && \
     cd /service/common/org.eclipse.theia.cloud.common && \
-    mvn clean install && \
+    mvn clean install --no-transfer-progress&& \
     cd /service/service/org.eclipse.theia.cloud.service && \
-    mvn clean package -Dmaven.test.skip=true -Dquarkus.package.type=uber-jar
+    mvn clean package -Dmaven.test.skip=true -Dquarkus.package.type=uber-jar --no-transfer-progress
 
 FROM openjdk:11-jre-slim-buster
 WORKDIR /service

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinitionSpec.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinitionSpec.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -54,7 +54,7 @@ public class AppDefinitionSpec {
     private int minInstances;
 
     @JsonProperty("maxInstances")
-    private int maxInstances;
+    private Integer maxInstances;
 
     @JsonProperty("timeout")
     private Timeout timeout;
@@ -119,7 +119,7 @@ public class AppDefinitionSpec {
 	return minInstances;
     }
 
-    public int getMaxInstances() {
+    public Integer getMaxInstances() {
 	return maxInstances;
     }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
@@ -39,7 +39,7 @@ public final class TheiaCloudK8sUtil {
 	    SessionSpec sessionSpec, AppDefinitionSpec appDefinitionSpec, String correlationId) {
 
 	if (appDefinitionSpec.getMaxInstances() == null || appDefinitionSpec.getMaxInstances() < 0) {
-	    LOGGER.info(formatLogMessage(correlationId,
+	    LOGGER.debug(formatLogMessage(correlationId,
 		    "App Definition " + appDefinitionSpec.getName() + " allows indefinite sessions."));
 	    return false;
 	}

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudK8sUtil.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -38,7 +38,7 @@ public final class TheiaCloudK8sUtil {
     public static boolean checkIfMaxInstancesReached(NamespacedKubernetesClient client, String namespace,
 	    SessionSpec sessionSpec, AppDefinitionSpec appDefinitionSpec, String correlationId) {
 
-	if (appDefinitionSpec.getMaxInstances() < 1) {
+	if (appDefinitionSpec.getMaxInstances() == null || appDefinitionSpec.getMaxInstances() < 0) {
 	    LOGGER.info(formatLogMessage(correlationId,
 		    "App Definition " + appDefinitionSpec.getName() + " allows indefinite sessions."));
 	    return false;


### PR DESCRIPTION
- Setting a app definitions `maxInstances` to `0` now prevents any launch
- Negative or omitted `maxInstances` allows indefinite launches

Further small changes:
- Disable printing transfer progress in operator and service docker builds to avoid log pollution
- Reduce log level for app definitions allowing indefinite instances. The reason is that the indefinite instances are the expected result directly following from the app definition. It seems unnecessary to log this as info over and over again.

Contributed on behalf of STMicroelectronics