### PR TITLE
Limit user access to their own resources

### DIFF
--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -19,10 +19,10 @@ jobs:
         distribution: 'temurin'
     - name: Build TheiaCloud common
       run: |
-        mvn clean install -f java/common/maven-conf
-        mvn clean install -f java/common/org.eclipse.theia.cloud.common
+        mvn clean install -f java/common/maven-conf --no-transfer-progress
+        mvn clean install -f java/common/org.eclipse.theia.cloud.common --no-transfer-progress
     - name: Run TheiaCloud service tests
-      run: mvn clean verify -fae -f java/service/org.eclipse.theia.cloud.service
+      run: mvn clean verify -fae -f java/service/org.eclipse.theia.cloud.service --no-transfer-progress
 
   docker:
     needs: tests

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/TheiaCloudError.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/TheiaCloudError.java
@@ -25,6 +25,7 @@ public class TheiaCloudError {
     public static final TheiaCloudError INVALID_WORKSPACE_NAME = new TheiaCloudError(471, "Invalid workspace name.");
     public static final TheiaCloudError INVALID_APP_DEFINITION_NAME = new TheiaCloudError(473,
 	    "Invalid app definition name.");
+    public static final TheiaCloudError INVALID_SESSION_NAME = new TheiaCloudError(474, "Invalid session name.");
     public static final TheiaCloudError MISSING_WORKSPACE_NAME = new TheiaCloudError(480, "Missing workspace name.");
     public static final TheiaCloudError MISSING_SESSION_NAME = new TheiaCloudError(481, "Missing session name.");
 

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
@@ -31,7 +31,7 @@ public class BaseResource {
     private ApplicationProperties applicationProperties;
 
     @Inject
-    TheiaCloudUser theiaCloudUser;
+    protected TheiaCloudUser theiaCloudUser;
 
     public BaseResource(ApplicationProperties applicationProperties) {
 	this.applicationProperties = applicationProperties;

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/BaseResource.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource and others.
+ * Copyright (C) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -17,6 +17,9 @@ package org.eclipse.theia.cloud.service;
 
 import static org.eclipse.theia.cloud.common.util.LogMessageUtil.generateCorrelationId;
 
+import javax.inject.Inject;
+import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.theia.cloud.common.util.LogMessageUtil;
 import org.eclipse.theia.cloud.common.util.TheiaCloudError;
 import org.jboss.logging.Logger;
@@ -25,13 +28,22 @@ public class BaseResource {
 
     protected final Logger logger;
     protected final String appId;
+    private ApplicationProperties applicationProperties;
+
+    @Inject
+    TheiaCloudUser theiaCloudUser;
 
     public BaseResource(ApplicationProperties applicationProperties) {
+	this.applicationProperties = applicationProperties;
 	appId = applicationProperties.getAppId();
 	logger = Logger.getLogger(getClass().getSuperclass());
     }
 
     protected String evaluateRequest(ServiceRequest request) {
+	return basicEvaluateRequest(request);
+    }
+
+    private String basicEvaluateRequest(ServiceRequest request) {
 	String correlationId = generateCorrelationId();
 	if (request == null || request.appId == null || !request.appId.equals(appId)) {
 	    info(correlationId, "Request '" + request.kind + "' without matching appId: " + request.appId);
@@ -39,6 +51,47 @@ public class BaseResource {
 	    throw new TheiaCloudWebException(TheiaCloudError.INVALID_APP_ID);
 	}
 	return correlationId;
+    }
+
+    /**
+     * Evaluates user scoped requests. In addition to the basic evaluation performed
+     * for every {@linkplain ServiceRequest}, this ensures that the requested user
+     * is the same as the authenticated user.
+     * 
+     * In anonymous mode, this ensures a user is set in the request.
+     * 
+     * @param request The {@link UserScopedServiceRequest} to evaluate
+     * @throws TheiaCloudWebException
+     * @return The {@link EvaluatedRequest} including the user identifier to use
+     */
+    protected EvaluatedRequest evaluateRequest(UserScopedServiceRequest request) {
+	String correlationId = basicEvaluateRequest(request);
+
+	// Keycloak is not used => user must be specified in request.
+	if (!applicationProperties.isUseKeycloak()) {
+	    if (request.user == null || request.user.isBlank()) {
+		info(correlationId,
+			"User was not specified for user scoped request. This is mandatory in anonymous mode.");
+		throw new TheiaCloudWebException(Status.BAD_REQUEST,
+			"Property \"user\" was not specified for user scoped request.");
+	    }
+	    return new EvaluatedRequest(correlationId, request.user);
+	}
+
+	// Keycloak is used. User must not be considered anonymous (i.e. have a
+	// non-empty identifier) and the request user must match the authenticated user
+	// (this might change if the concept of admin users is introduced later)
+	if (theiaCloudUser.isAnonymous()) {
+	    info(correlationId,
+		    "User is unexpectetly considered anonymous and, thus, must not access user scoped resources.");
+	    throw new TheiaCloudWebException(Status.UNAUTHORIZED);
+	} else if (request.user == null || request.user.equals(theiaCloudUser.getIdentifier())) {
+	    return new EvaluatedRequest(correlationId, theiaCloudUser.getIdentifier());
+	} else {
+	    info(correlationId, "User specified in the request does not match the authenticated user.");
+	    trace(correlationId, request.toString());
+	    throw new TheiaCloudWebException(Status.FORBIDDEN);
+	}
     }
 
     public void info(String correlationId, String message) {

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/EvaluatedRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/EvaluatedRequest.java
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (C) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+/**
+ * Information container for results of evaluating a service request.
+ */
+public class EvaluatedRequest {
+
+    private String correlationId;
+    private String user;
+
+    public EvaluatedRequest(String correlationId, String user) {
+	this.correlationId = correlationId;
+	this.user = user;
+    }
+
+    public String getCorrelationId() {
+	return correlationId;
+    }
+
+    /**
+     * @return The resolved user identifier for the request
+     */
+    public String getUser() {
+	return user;
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/LaunchRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/LaunchRequest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource and others.
+ * Copyright (C) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,17 +15,11 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.service;
 
-import java.util.List;
-import java.util.Map;
-
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(name = "LaunchRequest", description = "A request to launch a new session.")
-public class LaunchRequest extends ServiceRequest {
+public class LaunchRequest extends UserScopedServiceRequest {
     public static final String KIND = "launchRequest";
-
-    @Schema(description = "The user identification, usually the email address.", required = true)
-    public String user;
 
     @Schema(description = "The app to launch. Needs to be set if a new or ephemeral session should be launched. For an existing workspace the last app definition will be used if none is given.", required = false)
     public String appDefinition;

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/NoAnonymousAccess.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/NoAnonymousAccess.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+/**
+ * <p>
+ * Specifies that an annotated resource or method must never be accessed
+ * anonymously — even if TheiaCloud runs in anonymous mode.
+ * </p>
+ * <p>
+ * As this only makes sense with authentication, this annotation should be used
+ * in combination with {@link io.quarkus.security.Authenticated @Authenticated}
+ * or {@link javax.annotation.security.RolesAllowed @RolesAllowed}.
+ * </p>
+ * <p>
+ * Can be applied to a method or a resource class. In the latter case, the
+ * behavior applies to all its methods. This is the default behavior for all CDI
+ * interceptor bindings.
+ * </p>
+ * 
+ * @see ApplicationProperties#isUseKeycloak()
+ */
+@Inherited
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+public @interface NoAnonymousAccess {
+
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/NoAnonymousAccessInterceptor.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/NoAnonymousAccessInterceptor.java
@@ -1,0 +1,77 @@
+/********************************************************************************
+ * Copyright (C) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import javax.ws.rs.core.Response.Status;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Interceptor handling the {@link NoAnonymousAccess} annotation.
+ *
+ */
+@Interceptor
+@NoAnonymousAccess
+@Priority(value = Interceptor.Priority.APPLICATION)
+public class NoAnonymousAccessInterceptor {
+
+    @Inject
+    Logger logger;
+
+    @Inject
+    ApplicationProperties applicationProperties;
+
+    @Inject
+    TheiaCloudUser user;
+
+    /**
+     * Verifies that the user is not anonymous and Theia Cloud does not run in
+     * anonymous mode. Throws an exception for anonymous access.
+     * 
+     * @throws Exception              if following interceptors fail
+     * @throws TheiaCloudWebException on anonymous access
+     */
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+	if (!applicationProperties.isUseKeycloak()) {
+	    logger.infov("Blocked anonymous access to method {0}#{1}", ctx.getMethod().getDeclaringClass().getName(),
+		    ctx.getMethod().getName());
+	    // Note: Another possibility is to throw a 401 (Unauthorized) because the user
+	    // is not authenticated.
+	    // However, there is also no possible user account in anonymous mode to achieve
+	    // this.
+	    throw new TheiaCloudWebException(Status.FORBIDDEN);
+	} else if (user.isAnonymous()) {
+	    // Authentication is used and succeeded but the user is considered anonymous for
+	    // other reasons such as not having a user identifier
+	    final Optional<Method> method = Optional.ofNullable(ctx.getMethod());
+	    logger.infov("Blocked authenticated access with anonymous user profile to method {0}#{1}",
+		    method.map(m -> m.getDeclaringClass().getName()).orElse("<unknown>"),
+		    method.map(Method::getName).orElse("<unknown>"));
+	    throw new TheiaCloudWebException(Status.FORBIDDEN);
+	}
+
+	return ctx.proceed();
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/TheiaCloudUser.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/TheiaCloudUser.java
@@ -35,7 +35,9 @@ public class TheiaCloudUser {
      * display name because it can be any unique identifier such as a user name,
      * email address or UUID.
      * 
-     * @return the unique identifier
+     * @return the unique identifier, never null or
+     *         {@link java.lang.String#isBlank() blank} if {@link #isAnonymous()}
+     *         returns false
      */
     public String getIdentifier() {
 	return identifier;

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/TheiaCloudWebException.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/TheiaCloudWebException.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource and others.
+ * Copyright (C) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -34,6 +34,10 @@ public class TheiaCloudWebException extends WebApplicationException {
 
     public TheiaCloudWebException(Response.Status status) {
 	super(status);
+    }
+
+    public TheiaCloudWebException(Response.Status status, String message) {
+	super(message, status);
     }
 
     public TheiaCloudWebException(TheiaCloudError status) {

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/UserScopedServiceRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/UserScopedServiceRequest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022-2023 EclipseSource and others.
+ * Copyright (C) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,27 +13,23 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-package org.eclipse.theia.cloud.service.workspace;
+package org.eclipse.theia.cloud.service;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.theia.cloud.service.UserScopedServiceRequest;
 
-@Schema(name = "WorkspaceListRequest", description = "Request to list workspaces of a user.")
-public class WorkspaceListRequest extends UserScopedServiceRequest {
-    public static final String KIND = "workspaceListRequest";
+/**
+ * Service request specifying a user.
+ */
+public class UserScopedServiceRequest extends ServiceRequest {
 
-    public WorkspaceListRequest() {
-	super(KIND);
+    @Schema(description = "The user identification, usually the email address.", required = true)
+    public String user;
+
+    public UserScopedServiceRequest(String kind) {
+	super(kind);
     }
 
-    public WorkspaceListRequest(String appId, String user) {
-	super(KIND, appId);
-	this.user = user;
+    public UserScopedServiceRequest(String kind, String appId) {
+	super(kind, appId);
     }
-
-    @Override
-    public String toString() {
-	return "WorkspaceListRequest [user=" + user + ", appId=" + appId + ", kind=" + kind + "]";
-    }
-
 }

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionListRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionListRequest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -17,14 +17,11 @@
 package org.eclipse.theia.cloud.service.session;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.theia.cloud.service.ServiceRequest;
+import org.eclipse.theia.cloud.service.UserScopedServiceRequest;
 
 @Schema(name = "SessionListRequest", description = "A request to list the sessions of a user.")
-public class SessionListRequest extends ServiceRequest {
+public class SessionListRequest extends UserScopedServiceRequest {
     public static final String KIND = "sessionListRequest";
-
-    @Schema(description = "The user identification, usually the email address.", required = true)
-    public String user;
 
     public SessionListRequest() {
 	super(KIND);

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionStartRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionStartRequest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -18,14 +18,11 @@ package org.eclipse.theia.cloud.service.session;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.theia.cloud.service.EnvironmentVars;
-import org.eclipse.theia.cloud.service.ServiceRequest;
+import org.eclipse.theia.cloud.service.UserScopedServiceRequest;
 
 @Schema(name = "SessionStartRequest", description = "A request to start a session")
-public class SessionStartRequest extends ServiceRequest {
+public class SessionStartRequest extends UserScopedServiceRequest {
     public static final String KIND = "sessionStartRequest";
-
-    @Schema(description = "The user identification, usually the email address.", required = true)
-    public String user;
 
     @Schema(description = "The app to launch.", required = true)
     public String appDefinition;

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionStopRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/session/SessionStopRequest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource and others.
+ * Copyright (C) 2022-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,14 +16,11 @@
 package org.eclipse.theia.cloud.service.session;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.theia.cloud.service.ServiceRequest;
+import org.eclipse.theia.cloud.service.UserScopedServiceRequest;
 
 @Schema(name = "SessionStopRequest", description = "A request to stop a session")
-public class SessionStopRequest extends ServiceRequest {
+public class SessionStopRequest extends UserScopedServiceRequest {
     public static final String KIND = "sessionStopRequest";
-
-    @Schema(description = "The user identification, usually the email address.", required = true)
-    public String user;
 
     @Schema(description = "The name of the session to stop.", required = true)
     public String sessionName;

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/workspace/WorkspaceCreationRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/workspace/WorkspaceCreationRequest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -17,14 +17,11 @@
 package org.eclipse.theia.cloud.service.workspace;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.theia.cloud.service.ServiceRequest;
+import org.eclipse.theia.cloud.service.UserScopedServiceRequest;
 
 @Schema(name = "WorkspaceCreationRequest", description = "Request to create a new workspace.")
-public class WorkspaceCreationRequest extends ServiceRequest {
+public class WorkspaceCreationRequest extends UserScopedServiceRequest {
     public static final String KIND = "workspaceCreationRequest";
-
-    @Schema(description = "The user identification, usually the email address.", required = true)
-    public String user;
 
     @Schema(description = "The app this workspace will be used with.", required = false)
     public String appDefinition;

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/workspace/WorkspaceDeletionRequest.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/workspace/WorkspaceDeletionRequest.java
@@ -16,14 +16,11 @@
 package org.eclipse.theia.cloud.service.workspace;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.theia.cloud.service.ServiceRequest;
+import org.eclipse.theia.cloud.service.UserScopedServiceRequest;
 
 @Schema(name = "WorkspaceDeletionRequest", description = "Request to delete a workspace")
-public class WorkspaceDeletionRequest extends ServiceRequest {
+public class WorkspaceDeletionRequest extends UserScopedServiceRequest {
     public static final String KIND = "workspaceDeletionRequest";
-
-    @Schema(description = "The user identification, usually the email address.", required = true)
-    public String user;
 
     @Schema(description = "The name of the workspace to delete.", required = true)
     public String workspaceName;

--- a/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/workspace/WorkspaceResource.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/workspace/WorkspaceResource.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -34,7 +34,7 @@ import org.eclipse.theia.cloud.service.ApplicationProperties;
 import org.eclipse.theia.cloud.service.BaseResource;
 import org.eclipse.theia.cloud.service.EvaluatedRequest;
 import org.eclipse.theia.cloud.service.K8sUtil;
-import org.eclipse.theia.cloud.service.TheiaCloudUser;
+import org.eclipse.theia.cloud.service.NoAnonymousAccess;
 import org.eclipse.theia.cloud.service.TheiaCloudWebException;
 
 import io.quarkus.security.Authenticated;
@@ -54,6 +54,7 @@ public class WorkspaceResource extends BaseResource {
     @Operation(summary = "List workspaces", description = "Lists the workspaces of a user.")
     @GET
     @Path("/{appId}/{user}")
+    @NoAnonymousAccess
     public List<UserWorkspace> list(@PathParam("appId") String appId, @PathParam("user") String user) {
 	WorkspaceListRequest request = new WorkspaceListRequest(appId, user);
 	final EvaluatedRequest evaluatedRequest = evaluateRequest(request);
@@ -65,6 +66,7 @@ public class WorkspaceResource extends BaseResource {
 
     @Operation(summary = "Create workspace", description = "Creates a new workspace for a user.")
     @POST
+    @NoAnonymousAccess
     public UserWorkspace create(WorkspaceCreationRequest request) {
 	final EvaluatedRequest evaluatedRequest = evaluateRequest(request);
 	final String correlationId = evaluatedRequest.getCorrelationId();
@@ -78,6 +80,7 @@ public class WorkspaceResource extends BaseResource {
 
     @Operation(summary = "Delete workspace", description = "Deletes a workspace.")
     @DELETE
+    @NoAnonymousAccess
     public boolean delete(WorkspaceDeletionRequest request) {
 	final EvaluatedRequest evaluatedRequest = evaluateRequest(request);
 	final String correlationId = evaluatedRequest.getCorrelationId();

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/NoAnonymousAccessInterceptorTests.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/NoAnonymousAccessInterceptorTests.java
@@ -1,0 +1,117 @@
+/********************************************************************************
+ * Copyright (C) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response.Status;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+/**
+ * Tests for {@link NoAnonymousAccessInterceptor}.
+ */
+@QuarkusTest
+public class NoAnonymousAccessInterceptorTests {
+
+    @InjectMock
+    ApplicationProperties applicationProperties;
+
+    @InjectMock
+    TheiaCloudUser user;
+
+    @Inject
+    NoAnonymousAccessWithMethodAnnotationTestResource methodFixture;
+
+    @Inject
+    NoAnonymousAccessWithMethodAnnotationTestResource clazzFixture;
+
+    @Test
+    void intercept_useKeyloakWithIdentifiedUser_proceed() {
+	Mockito.when(applicationProperties.isUseKeycloak()).thenReturn(true);
+	mockUser("someuser");
+
+	methodFixture.execute();
+	clazzFixture.execute();
+    }
+
+    @Test
+    void intercept_useKeyloakWithoutIdentifiedUser_throwForbidden() throws Exception {
+	Mockito.when(applicationProperties.isUseKeycloak()).thenReturn(true);
+	mockUser(null);
+
+	TheiaCloudWebException methodException = assertThrows(TheiaCloudWebException.class, () -> {
+	    methodFixture.execute();
+	});
+	assertEquals(Status.FORBIDDEN.getStatusCode(), methodException.getResponse().getStatus());
+
+	TheiaCloudWebException clazzException = assertThrows(TheiaCloudWebException.class, () -> {
+	    clazzFixture.execute();
+	});
+	assertEquals(Status.FORBIDDEN.getStatusCode(), clazzException.getResponse().getStatus());
+    }
+
+    @Test
+    void intercept_noKeyloak_throwForbidden() {
+	Mockito.when(applicationProperties.isUseKeycloak()).thenReturn(false);
+	mockUser(null);
+
+	TheiaCloudWebException methodException = assertThrows(TheiaCloudWebException.class, () -> {
+	    methodFixture.execute();
+	});
+	assertEquals(Status.FORBIDDEN.getStatusCode(), methodException.getResponse().getStatus());
+
+	TheiaCloudWebException clazzException = assertThrows(TheiaCloudWebException.class, () -> {
+	    clazzFixture.execute();
+	});
+	assertEquals(Status.FORBIDDEN.getStatusCode(), clazzException.getResponse().getStatus());
+    }
+
+    private void mockUser(String name) {
+	Mockito.when(user.getIdentifier()).thenReturn(name);
+	Mockito.when(user.isAnonymous()).thenReturn(name == null || name.isBlank());
+    }
+
+    /*
+     * Configure a test bean like a resource that uses the @NoAnonymousAccess
+     * annotation: With a Path annotation and an annotated method.
+     */
+    @Path("/some/path")
+    static class NoAnonymousAccessWithMethodAnnotationTestResource {
+	@NoAnonymousAccess
+	void execute() {
+	}
+    }
+
+    /*
+     * Configure a test bean like a resource that uses the @NoAnonymousAccess
+     * annotation: With a Path annotation and the annotation placed on the resource
+     * class.
+     */
+    @Path("/someother/path")
+    @NoAnonymousAccess
+    static class NoAnonymousAccessWithClassAnnotationTestResource {
+	void execute() {
+	}
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/RootResourceTests.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/RootResourceTests.java
@@ -1,0 +1,87 @@
+/********************************************************************************
+ * Copyright (C) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response.Status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.quarkus.test.security.TestSecurity;
+
+/**
+ * Unit tests for {@link RootResource}.
+ *
+ * Disable authorization via {@link TestSecurity} annotation as this is a unit
+ * test of the resource itself. Thus, we do not want authentication interceptors
+ * to trigger when calling the resource's methods.
+ */
+@QuarkusTest
+@TestSecurity(authorizationEnabled = false)
+class RootResourceTests {
+
+    private static final String APP_ID = "asdfghjkl";
+    private static final String TEST_USER = "TestUser";
+    private static final String OTHER_TEST_USER = "OtherTestUser";
+
+    @InjectMock
+    ApplicationProperties applicationProperties;
+
+    @InjectMock
+    TheiaCloudUser user;
+
+    @Inject
+    RootResource fixture;
+
+    @BeforeEach
+    void mockApplicationProperties() {
+	Mockito.when(applicationProperties.isUseKeycloak()).thenReturn(true);
+    }
+
+    @Test
+    void launch_otherUser_throwForbidden() {
+	// Prepare
+	mockUser(false, TEST_USER);
+	LaunchRequest launchRequest = new LaunchRequest();
+	launchRequest.appId = APP_ID;
+	launchRequest.user = OTHER_TEST_USER;
+
+	// Execute
+	TheiaCloudWebException exception = assertThrows(TheiaCloudWebException.class, () -> {
+	    fixture.launch(launchRequest);
+
+	});
+
+	// Assert
+	assertEquals(Status.FORBIDDEN.getStatusCode(), exception.getResponse().getStatus());
+    }
+
+    // ---
+    // Utility methods
+    // ---
+
+    private void mockUser(boolean anonymous, String name) {
+	Mockito.when(user.isAnonymous()).thenReturn(anonymous);
+	Mockito.when(user.getIdentifier()).thenReturn(name);
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/test/TestUtil.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/test/TestUtil.java
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (C) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.service.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+
+import org.eclipse.theia.cloud.service.NoAnonymousAccess;
+
+import io.quarkus.security.Authenticated;
+
+/**
+ * Utility methods for testing service functionality.
+ *
+ */
+public final class TestUtil {
+
+    private TestUtil() {
+    }
+
+    /**
+     * Verifies that the given method does not allow any anonymous access by
+     * checking:
+     * <ul>
+     * <li>That either the class or the method require authentication and do not
+     * permit all access
+     * <li>The method and/or its class declare the {@link NoAnonymousAccess}
+     * annotation
+     * </ul>
+     * 
+     * @param method The method to verify
+     */
+    public static void assertNoAnonymousAccessAnnotations(Method method) {
+	Class<?> clazz = method.getDeclaringClass();
+
+	boolean classHasAccessControl = ((clazz.getDeclaredAnnotation(Authenticated.class) != null
+		|| clazz.getDeclaredAnnotation(RolesAllowed.class) != null))
+		&& clazz.getDeclaredAnnotation(PermitAll.class) == null;
+	boolean methodHasAccessControl = (method.getDeclaredAnnotation(Authenticated.class) != null
+		|| method.getDeclaredAnnotation(RolesAllowed.class) != null);
+	boolean methodNoPermitAll = method.getDeclaredAnnotation(PermitAll.class) == null;
+	assertTrue((classHasAccessControl || methodHasAccessControl) && methodNoPermitAll,
+		"The method and/or its class have declared restricting access control annotations.");
+
+	boolean hasNoAnonymousAccessAnnotation = method.getDeclaredAnnotation(NoAnonymousAccess.class) != null
+		|| clazz.getDeclaredAnnotation(NoAnonymousAccess.class) != null;
+	assertTrue(hasNoAnonymousAccessAnnotation,
+		"The method and/or its class declare the annotation to forbid any anonymous access.");
+    }
+}

--- a/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/workspace/WorkspaceResourceTests.java
+++ b/java/service/org.eclipse.theia.cloud.service/src/test/java/org/eclipse/theia/cloud/service/workspace/WorkspaceResourceTests.java
@@ -28,9 +28,11 @@ import javax.ws.rs.core.Response.Status;
 
 import org.eclipse.theia.cloud.common.k8s.resource.WorkspaceSpec;
 import org.eclipse.theia.cloud.common.util.TheiaCloudError;
+import org.eclipse.theia.cloud.service.ApplicationProperties;
 import org.eclipse.theia.cloud.service.K8sUtil;
 import org.eclipse.theia.cloud.service.TheiaCloudUser;
 import org.eclipse.theia.cloud.service.TheiaCloudWebException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -55,6 +57,9 @@ public class WorkspaceResourceTests {
     private static final String TEST_WORKSPACE = "TestWorkspace";
 
     @InjectMock
+    ApplicationProperties applicationProperties;
+
+    @InjectMock
     K8sUtil k8sUtil;
 
     @InjectMock
@@ -62,6 +67,11 @@ public class WorkspaceResourceTests {
 
     @Inject
     WorkspaceResource fixture;
+
+    @BeforeEach
+    void mockApplicationProperties() {
+	Mockito.when(applicationProperties.isUseKeycloak()).thenReturn(true);
+    }
 
     /**
      * Test method for

--- a/node/testing-page/src/App.tsx
+++ b/node/testing-page/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import './App.css';
 import { KeycloakConfig } from 'keycloak-js';
 import Keycloak from 'keycloak-js';
-import { TheiaCloud, RequestOptions, SessionListRequest, SessionStartRequest, SessionStopRequest, WorkspaceCreationRequest, WorkspaceDeletionRequest, WorkspaceListRequest } from '@eclipse-theiacloud/common';
+import { TheiaCloud, RequestOptions, SessionListRequest, SessionStartRequest, SessionStopRequest, WorkspaceCreationRequest, WorkspaceDeletionRequest, WorkspaceListRequest, PingRequest, LaunchRequest } from '@eclipse-theiacloud/common';
 
 const KEYCLOAK_CONFIG: KeycloakConfig = {
   url: 'https://keycloak.localdemo.io/auth/',
@@ -70,6 +70,25 @@ function App() {
     }).catch(err => {
       console.error('Request failed:', err);
     })
+  }
+
+  // Root requests
+  const ping = (_user: string, accessToken?: string) => {
+    const request: PingRequest = {
+      appId: APP_ID,
+      serviceUrl: SERVICE_URL,
+    };
+    return TheiaCloud.ping(request, generateRequestOptions(accessToken))
+  }
+  const launch = (user: string, accessToken?: string) => {
+    const request: LaunchRequest = {
+      appId: APP_ID,
+      appDefinition: APP_DEFINITION,
+      user,
+      serviceUrl: SERVICE_URL,
+      timeout: 3
+    }
+    return TheiaCloud.launch(request, generateRequestOptions(accessToken));
   }
 
   // Workspace requests
@@ -145,6 +164,10 @@ function App() {
       <p>
         <span>Session/Workspace:</span>
         <input type='text' value={resourceName} onChange={ev => setResourceName(ev.target.value)} />
+      </p>
+      <p>
+        <button onClick={() => executeRequest(ping)}>Ping</button>
+        <button onClick={() => executeRequest(launch)}>Launch</button>
       </p>
       <p>
         <button onClick={() => executeRequest(listSessions)}>List Sessions</button>

--- a/terraform/test-configurations/2_try-now/theia_cloud.tf
+++ b/terraform/test-configurations/2_try-now/theia_cloud.tf
@@ -67,6 +67,12 @@ resource "helm_release" "theia-cloud" {
     name  = "ingress.theiaCloudCommonName"
     value = true
   }
+
+  # Comment in to only pull missing images. This is needed to use images built locally in Minikube
+  # set {
+  #   name  = "imagePullPolicy"
+  #   value = "IfNotPresent"
+  # }
 }
 
 resource "kubectl_manifest" "cdt-cloud-demo" {


### PR DESCRIPTION
Fix #180 

## Summary
This PR extends the REST service to limit user access to their own resources for all calls.
Now, Users may only create, start, stop, list, and get performance metrics for their own sessions and workspaces. Trying to do any of this in the name of another user (by specifying them in the request's user field) throws a `403` Forbidden HTTP Error.

Furthermore, all authenticated methods (everything but ping and and Session.activity) except for the launch method, can no longer be used in anonymous mode. This is achieved via a new `@NoAnonymousAccess` annotation triggering an interceptor. With this, anonymous requests return a `403` Forbidden HTTP Error in anonymous mode.

## How to test

- Use the terraform testing config
- Execute the minikube setup
- Build service in Minikube by first pointing docker to minikube's docker registry via `eval $(minikube docker-env)`
- In `terraform/test-configurations/2_try-now/theia_cloud.tf`, adapt the helm values to use the custom built service image by adding config to set the helm values accordingly, e.g. like this:
```terraform
# Only pull missing images. This is needed to use images built locally in Minikube
  set {
  name  = "imagePullPolicy"
  value = "IfNotPresent"
  }

  set {
    name  = "service.image"
    value = "theia-cloud-service:180-user-resource-access"
  }
```
- Install the theia-cloud-base and try-now setups
- Use the node testing page to execute rest calls on the service. Adapt the service url and keycloak url in `node/testing-page/src/App.tsx`

## Implementation details

<details>

### Generalize user scoped requests in new class 
Add a new sub class UserScopedServiceRequest of ServiceRequest to unify
specification of a user for all requests using one.

### Allow user-scoped requests only for the same authenticated user 

So far, most methods did not verify that the user named in the requestis the same as the authenticated user.

This commit fixes this by overloading the evaluateRequest method in BaseResource with a second version taking a UserScopedServiceRequest.

For these requests, request.user must either be the same as the authenticated user's identifier or be omitted. In the latter case, the user's identifier is used automatically.

In anonymous mode, the request.user property must be set because there is no other way to determine the user.

In both cases, the resolved user identifier to use is returned as part of the new type `EvaluatedRequest`.

### Add annotation to prevent any anonymous access 
Adds a new interceptor binding annotation `@NoAnonymousAccess` and the corresponding interceptor implementation that blocks all anonymous access to a resource class or method.

### Block any anonymous access to various session and workspace methods 

- Block any anonymous access for methods:
  - Session: list, performance, start, stop
  - Workspace: create, delete, list
- Add new error code 474 for invalid session name
- Adds tests:
  - Session: performance, list, start, verify access control annotations
  - Workspace: create, list, verify access control annotations
  - Root: Ensure users cannot launch sessions for other users
 
### Misc
- Extend testing page with ping and launch buttons
- Add imagePullPolicy hint to testing terraform config
- Disable mvn transfer progress for service test ci
</details>