### PR TITLE
Operator should not get hostname from app definitions

### DIFF
--- a/demo/dockerfiles/demo-operator-custom-template/templateDeployment.yaml
+++ b/demo/dockerfiles/demo-operator-custom-template/templateDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: placeholder-depname
   namespace: placeholder-namespace
   ownerReferences:
-    - apiVersion: theia.cloud/v5beta
+    - apiVersion: theia.cloud/v6beta
       kind: AppDefinition
       name: placeholder
       uid: placeholder

--- a/demo/dockerfiles/demo-operator-custom-template/templateDeploymentWithoutOAuthProxy.yaml
+++ b/demo/dockerfiles/demo-operator-custom-template/templateDeploymentWithoutOAuthProxy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: placeholder-depname
   namespace: placeholder-namespace
   ownerReferences:
-    - apiVersion: theia.cloud/v5beta
+    - apiVersion: theia.cloud/v6beta
       kind: AppDefinition
       name: placeholder
       uid: placeholder

--- a/demo/k8s/appdefinitions/cdt.yaml
+++ b/demo/k8s/appdefinitions/cdt.yaml
@@ -1,11 +1,10 @@
-apiVersion: theia.cloud/v5beta
+apiVersion: theia.cloud/v6beta
 kind: AppDefinition
 metadata:
   name: cdt-cloud-demo
   namespace: theiacloud
 spec:
   downlinkLimit: 30000
-  host: ws.theia-cloud.io
   image: theiacloud/cdt-cloud:v1.34.4
   imagePullPolicy: IfNotPresent
   ingressname: theia-cloud-demo-ws-ingress

--- a/demo/k8s/appdefinitions/coffee-editor.yaml
+++ b/demo/k8s/appdefinitions/coffee-editor.yaml
@@ -1,11 +1,10 @@
-apiVersion: theia.cloud/v5beta
+apiVersion: theia.cloud/v6beta
 kind: AppDefinition
 metadata:
   name: coffee-editor
   namespace: theiacloud
 spec:
   downlinkLimit: 30000
-  host: ws.theia-cloud.io
   image: eu.gcr.io/kubernetes-238012/coffee-editor:v0.7.17
   imagePullPolicy: IfNotPresent
   ingressname: theia-cloud-demo-ws-ingress

--- a/demo/k8s/appdefinitions/theia.yaml
+++ b/demo/k8s/appdefinitions/theia.yaml
@@ -1,11 +1,10 @@
-apiVersion: theia.cloud/v5beta
+apiVersion: theia.cloud/v6beta
 kind: AppDefinition
 metadata:
   name: theia-cloud-demo
   namespace: theiacloud
 spec:
   downlinkLimit: 30000
-  host: ws.theia-cloud.io
   image: theiacloud/theia-cloud-demo:0.8.0
   imagePullPolicy: IfNotPresent
   ingressname: theia-cloud-demo-ws-ingress

--- a/helm/theia.cloud/test/cdt.yaml
+++ b/helm/theia.cloud/test/cdt.yaml
@@ -1,4 +1,4 @@
-apiVersion: theia.cloud/v5beta
+apiVersion: theia.cloud/v6beta
 kind: AppDefinition
 metadata:
   name: cdt-cloud-demo
@@ -9,7 +9,6 @@ spec:
   pullSecret: ""
   uid: 101
   port: 3000
-  host: ws.192.168.39.3.nip.io
   ingressname: theia-cloud-demo-ws-ingress
   minInstances: 0
   maxInstances: 10

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinition.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinition.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -25,7 +25,7 @@ import io.fabric8.kubernetes.model.annotation.Plural;
 import io.fabric8.kubernetes.model.annotation.Singular;
 import io.fabric8.kubernetes.model.annotation.Version;
 
-@Version("v5beta")
+@Version("v6beta")
 @Group("theia.cloud")
 @Singular("appdefinition")
 @Plural("appdefinitions")

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinitionSpec.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/AppDefinitionSpec.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @JsonDeserialize()
 public class AppDefinitionSpec {
 
-    public static final String API = "theia.cloud/v5beta";
+    public static final String API = "theia.cloud/v6beta";
     public static final String KIND = "AppDefinition";
     public static final String CRD_NAME = "appdefinitions.theia.cloud";
 
@@ -43,9 +43,6 @@ public class AppDefinitionSpec {
 
     @JsonProperty("port")
     private int port;
-
-    @JsonProperty("host")
-    private String host;
 
     @JsonProperty("ingressname")
     private String ingressname;
@@ -107,10 +104,6 @@ public class AppDefinitionSpec {
 	return port;
     }
 
-    public String getHost() {
-	return host;
-    }
-
     public String getIngressname() {
 	return ingressname;
     }
@@ -162,9 +155,9 @@ public class AppDefinitionSpec {
     @Override
     public String toString() {
 	return "AppDefinitionSpec [name=" + name + ", image=" + image + ", imagePullPolicy=" + imagePullPolicy
-		+ ", pullSecret=" + pullSecret + ", uid=" + uid + ", port=" + port + ", host=" + host + ", ingressname="
-		+ ingressname + ", minInstances=" + minInstances + ", maxInstances=" + maxInstances + ", timeout="
-		+ timeout + ", requestsMemory=" + requestsMemory + ", requestsCpu=" + requestsCpu + ", limitsMemory="
+		+ ", pullSecret=" + pullSecret + ", uid=" + uid + ", port=" + port + ", ingressname=" + ingressname
+		+ ", minInstances=" + minInstances + ", maxInstances=" + maxInstances + ", timeout=" + timeout
+		+ ", requestsMemory=" + requestsMemory + ", requestsCpu=" + requestsCpu + ", limitsMemory="
 		+ limitsMemory + ", limitsCpu=" + limitsCpu + ", downlinkLimit=" + downlinkLimit + ", uplinkLimit="
 		+ uplinkLimit + ", mountPath=" + mountPath + "]";
     }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
@@ -68,6 +68,10 @@ public class TheiaCloudArguments {
     private String appId;
 
     @Option(names = {
+	    "--instancesHost" }, description = "Hostname instances are hosted at. Does not include subpaths.", required = true)
+    private String instancesHost;
+
+    @Option(names = {
 	    "--usePaths" }, description = "Whether paths instead of subdomains are used for the various components", required = false)
     private boolean usePaths;
 
@@ -138,6 +142,10 @@ public class TheiaCloudArguments {
 	return appId;
     }
 
+    public String getInstancesHost() {
+	return instancesHost;
+    }
+
     public boolean isUsePaths() {
 	return usePaths;
     }
@@ -176,6 +184,7 @@ public class TheiaCloudArguments {
 	result = prime * result + (eagerStart ? 1231 : 1237);
 	result = prime * result + (enableActivityTracker ? 1231 : 1237);
 	result = prime * result + (enableMonitor ? 1231 : 1237);
+	result = prime * result + ((instancesHost == null) ? 0 : instancesHost.hashCode());
 	result = prime * result + ((instancesPath == null) ? 0 : instancesPath.hashCode());
 	result = prime * result + ((keycloakClientId == null) ? 0 : keycloakClientId.hashCode());
 	result = prime * result + ((keycloakRealm == null) ? 0 : keycloakRealm.hashCode());
@@ -214,6 +223,11 @@ public class TheiaCloudArguments {
 	if (enableActivityTracker != other.enableActivityTracker)
 	    return false;
 	if (enableMonitor != other.enableMonitor)
+	    return false;
+	if (instancesHost == null) {
+	    if (other.instancesHost != null)
+		return false;
+	} else if (!instancesHost.equals(other.instancesHost))
 	    return false;
 	if (instancesPath == null) {
 	    if (other.instancesPath != null)
@@ -278,9 +292,10 @@ public class TheiaCloudArguments {
 		+ enableMonitor + ", enableActivityTracker=" + enableActivityTracker + ", monitorInterval="
 		+ monitorInterval + ", cloudProvider=" + cloudProvider + ", bandwidthLimiter=" + bandwidthLimiter
 		+ ", wondershaperImage=" + wondershaperImage + ", serviceUrl=" + serviceUrl + ", sessionsPerUser="
-		+ sessionsPerUser + ", appId=" + appId + ", usePaths=" + usePaths + ", instancesPath=" + instancesPath
-		+ ", storageClassName=" + storageClassName + ", requestedStorage=" + requestedStorage + ", keycloakURL="
-		+ keycloakURL + ", keycloakRealm=" + keycloakRealm + ", keycloakClientId=" + keycloakClientId + "]";
+		+ sessionsPerUser + ", appId=" + appId + ", instancesHost=" + instancesHost + ", usePaths=" + usePaths
+		+ ", instancesPath=" + instancesPath + ", storageClassName=" + storageClassName + ", requestedStorage="
+		+ requestedStorage + ", keycloakURL=" + keycloakURL + ", keycloakRealm=" + keycloakRealm
+		+ ", keycloakClientId=" + keycloakClientId + "]";
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
@@ -110,15 +110,15 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 
     protected Map<String, String> getEnvironmentVariables(AppDefinition appDefinition, Session session) {
 	Map<String, String> environmentVariables = getEnvironmentVariables(appDefinition, Optional.of(session));
-	environmentVariables.put(PLACEHOLDER_ENV_SESSION_URL,
-		TheiaCloudDeploymentUtil.getSessionURL(ingressPathProvider, appDefinition, session));
+	environmentVariables.put(PLACEHOLDER_ENV_SESSION_URL, TheiaCloudDeploymentUtil
+		.getSessionURL(arguments.getInstancesHost(), ingressPathProvider, appDefinition, session));
 	return environmentVariables;
     }
 
     protected Map<String, String> getEnvironmentVariables(AppDefinition appDefinition, int instance) {
 	Map<String, String> environmentVariables = getEnvironmentVariables(appDefinition, Optional.empty());
-	environmentVariables.put(PLACEHOLDER_ENV_SESSION_URL,
-		TheiaCloudDeploymentUtil.getSessionURL(ingressPathProvider, appDefinition, instance));
+	environmentVariables.put(PLACEHOLDER_ENV_SESSION_URL, TheiaCloudDeploymentUtil
+		.getSessionURL(arguments.getInstancesHost(), ingressPathProvider, appDefinition, instance));
 	return environmentVariables;
     }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/EagerStartAppDefinitionAddedHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/EagerStartAppDefinitionAddedHandler.java
@@ -222,8 +222,7 @@ public class EagerStartAppDefinitionAddedHandler implements AppDefinitionHandler
 	K8sUtil.loadAndCreateConfigMapWithOwnerReference(client, namespace, correlationId, configMapYaml,
 		AppDefinitionSpec.API, AppDefinitionSpec.KIND, appDefinitionResourceName, appDefinitionResourceUID, 0,
 		configMap -> {
-		    String host = appDefinition.getSpec().getHost()
-			    + ingressPathProvider.getPath(appDefinition, instance);
+		    String host = arguments.getInstancesHost() + ingressPathProvider.getPath(appDefinition, instance);
 		    int port = appDefinition.getSpec().getPort();
 		    AddedHandlerUtil.updateProxyConfigMap(client, namespace, configMap, host, port);
 		});

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/EagerStartSessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/EagerStartSessionHandler.java
@@ -210,7 +210,7 @@ public class EagerStartSessionHandler implements SessionHandler {
 
     protected synchronized String updateIngress(Optional<Ingress> ingress, Optional<Service> serviceToUse,
 	    String appDefinitionID, int instance, int port, AppDefinition appDefinition, String correlationId) {
-	String host = appDefinition.getSpec().getHost();
+	final String host = arguments.getInstancesHost();
 	String path = ingressPathProvider.getPath(appDefinition, instance);
 	client.ingresses().edit(correlationId, ingress.get().getMetadata().getName(),
 		ingressToUpdate -> addIngressRule(ingressToUpdate, serviceToUse.get(), host, port, path));

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazySessionHandler.java
@@ -311,8 +311,7 @@ public class LazySessionHandler implements SessionHandler {
 	K8sUtil.loadAndCreateConfigMapWithOwnerReference(client.kubernetes(), client.namespace(), correlationId,
 		configMapYaml, SessionSpec.API, SessionSpec.KIND, sessionResourceName, sessionResourceUID, 0,
 		configMap -> {
-		    String host = appDefinition.getSpec().getHost()
-			    + ingressPathProvider.getPath(appDefinition, session);
+		    String host = arguments.getInstancesHost() + ingressPathProvider.getPath(appDefinition, session);
 		    int port = appDefinition.getSpec().getPort();
 		    AddedHandlerUtil.updateProxyConfigMap(client.kubernetes(), client.namespace(), configMap, host,
 			    port);
@@ -371,7 +370,7 @@ public class LazySessionHandler implements SessionHandler {
 
     protected synchronized String updateIngress(Optional<Ingress> ingress, Optional<Service> serviceToUse,
 	    Session session, AppDefinition appDefinition, String correlationId) {
-	String host = appDefinition.getSpec().getHost();
+	final String host = arguments.getInstancesHost();
 	String path = ingressPathProvider.getPath(appDefinition, session);
 	client.ingresses().edit(correlationId, ingress.get().getMetadata().getName(), ingressToUpdate -> {
 	    IngressRule ingressRule = new IngressRule();

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudDeploymentUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/util/TheiaCloudDeploymentUtil.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
+ * Copyright (C) 2022-2023 EclipseSource, Lockular, Ericsson, STMicroelectronics and 
  * others.
  *
  * This program and the accompanying materials are made available under the
@@ -40,14 +40,14 @@ public final class TheiaCloudDeploymentUtil {
     private TheiaCloudDeploymentUtil() {
     }
 
-    public static String getSessionURL(IngressPathProvider ingressPathProvider, AppDefinition appDefinition,
-	    Session session) {
-	return getSessionURL(appDefinition.getSpec().getHost(), ingressPathProvider.getPath(appDefinition, session));
+    public static String getSessionURL(String host, IngressPathProvider ingressPathProvider,
+	    AppDefinition appDefinition, Session session) {
+	return getSessionURL(host, ingressPathProvider.getPath(appDefinition, session));
     }
 
-    public static String getSessionURL(IngressPathProvider ingressPathProvider, AppDefinition appDefinition,
-	    int instance) {
-	return getSessionURL(appDefinition.getSpec().getHost(), ingressPathProvider.getPath(appDefinition, instance));
+    public static String getSessionURL(String host, IngressPathProvider ingressPathProvider,
+	    AppDefinition appDefinition, int instance) {
+	return getSessionURL(host, ingressPathProvider.getPath(appDefinition, instance));
     }
 
     private static String getSessionURL(String host, String path) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateConfigmap.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateConfigmap.yaml
@@ -6,7 +6,7 @@ metadata:
     theiacloud: proxy
   namespace: placeholder-namespace
   ownerReferences:
-    - apiVersion: theia.cloud/v5beta
+    - apiVersion: theia.cloud/v6beta
       kind: AppDefinition
       name: placeholder
       uid: placeholder

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateConfigmapEmails.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateConfigmapEmails.yaml
@@ -6,7 +6,7 @@ metadata:
     theiacloud: emails
   namespace: placeholder-namespace
   ownerReferences:
-    - apiVersion: theia.cloud/v5beta
+    - apiVersion: theia.cloud/v6beta
       kind: AppDefinition
       name: placeholder
       uid: placeholder

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: placeholder-depname
   namespace: placeholder-namespace
   ownerReferences:
-    - apiVersion: theia.cloud/v5beta
+    - apiVersion: theia.cloud/v6beta
       kind: AppDefinition
       name: placeholder
       uid: placeholder

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateService.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateService.yaml
@@ -6,7 +6,7 @@ metadata:
     app: placeholder-app
   namespace: placeholder-namespace
   ownerReferences:
-    - apiVersion: theia.cloud/v5beta
+    - apiVersion: theia.cloud/v6beta
       kind: AppDefinition
       name: placeholder
       uid: placeholder

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateServiceWithoutOAuthProxy.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateServiceWithoutOAuthProxy.yaml
@@ -6,7 +6,7 @@ metadata:
     app: placeholder-app
   namespace: placeholder-namespace
   ownerReferences:
-    - apiVersion: theia.cloud/v5beta
+    - apiVersion: theia.cloud/v6beta
       kind: AppDefinition
       name: placeholder
       uid: placeholder

--- a/terraform/test-configurations/2-01_try-now/theia_cloud.tf
+++ b/terraform/test-configurations/2-01_try-now/theia_cloud.tf
@@ -78,14 +78,13 @@ resource "helm_release" "theia-cloud" {
 resource "kubectl_manifest" "cdt-cloud-demo" {
   depends_on = [helm_release.theia-cloud]
   yaml_body  = <<-EOF
-  apiVersion: theia.cloud/v5beta
+  apiVersion: theia.cloud/v6beta
   kind: AppDefinition
   metadata:
     name: cdt-cloud-demo
     namespace: theiacloud
   spec:
     downlinkLimit: 30000
-    host: ws.${data.terraform_remote_state.minikube.outputs.hostname}
     image: theiacloud/cdt-cloud:v1.34.4
     imagePullPolicy: IfNotPresent
     ingressname: theia-cloud-demo-ws-ingress
@@ -115,14 +114,13 @@ resource "kubectl_manifest" "cdt-cloud-demo" {
 resource "kubectl_manifest" "coffee-editor" {
   depends_on = [helm_release.theia-cloud]
   yaml_body  = <<-EOF
-  apiVersion: theia.cloud/v5beta
+  apiVersion: theia.cloud/v6beta
   kind: AppDefinition
   metadata:
     name: coffee-editor
     namespace: theiacloud
   spec:
     downlinkLimit: 30000
-    host: ws.${data.terraform_remote_state.minikube.outputs.hostname}
     image: eu.gcr.io/kubernetes-238012/coffee-editor:v0.7.17
     imagePullPolicy: IfNotPresent
     ingressname: theia-cloud-demo-ws-ingress

--- a/terraform/test-configurations/2-03_try-now_paths/.terraform.lock.hcl
+++ b/terraform/test-configurations/2-03_try-now_paths/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/gavinbunney/kubectl" {
+  version     = "1.14.0"
+  constraints = ">= 1.14.0"
+  hashes = [
+    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
+    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
+    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
+    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
+    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
+    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
+    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
+    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
+    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
+    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.9.0"
+  constraints = ">= 2.9.0"
+  hashes = [
+    "h1:D5BLFN82WndhQZQleXE5rO0hUDnlyqb60XeUJKDhuo4=",
+    "zh:1471cb45908b426104687c962007b2980cfde294fa3530fabc4798ce9fb6c20c",
+    "zh:1572e9cec20591ec08ece797b3630802be816a5adde36ca91a93359f2430b130",
+    "zh:1b10ae03cf5ab1ae21ffaac2251de99797294ae4242b156b3b0beebbdbcb7e0f",
+    "zh:3bd043b68de967d8d0b549d3f71485193d81167d5656f5507d743dedfe60e352",
+    "zh:538911921c729185900176cc22eb8edcb822bc8d22b9ebb48103a1d9bb53cc38",
+    "zh:69a6a2d40c0463662c3fb1621e37a3ee65024ea4479adf4d5f7f19fb0dea48c2",
+    "zh:94b58daa0c351a49d01f6d8f1caae46c95c2d6c3f29753e2b9ea3e3c0e7c9ab4",
+    "zh:9d0543331a4a32241e1ab5457f30b41df745acb235a0391205c725a5311e4809",
+    "zh:a6789306524ca121512a95e873e3949b4175114a6c5db32bed2df2551a79368f",
+    "zh:d146b94cd9502cca7f2044797a328d71c7ec2a98e2d138270d8a28c872f04289",
+    "zh:d14ccd14511f0446eacf43a9243f22de7c1427ceb059cf67d7bf9803be2cb15d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/test-configurations/2-03_try-now_paths/outputs.tf
+++ b/terraform/test-configurations/2-03_try-now_paths/outputs.tf
@@ -1,0 +1,15 @@
+output "service" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/service"
+}
+
+output "instance" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/instances"
+}
+
+output "keycloak" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/keycloak/"
+}
+
+output "landing" {
+  value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/try"
+}

--- a/terraform/test-configurations/2-03_try-now_paths/theia_cloud.tf
+++ b/terraform/test-configurations/2-03_try-now_paths/theia_cloud.tf
@@ -1,0 +1,160 @@
+data "terraform_remote_state" "minikube" {
+  backend = "local"
+
+  config = {
+    path = "${path.module}/../0_minikube-setup/terraform.tfstate"
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.terraform_remote_state.minikube.outputs.host
+    client_certificate     = data.terraform_remote_state.minikube.outputs.client_certificate
+    client_key             = data.terraform_remote_state.minikube.outputs.client_key
+    cluster_ca_certificate = data.terraform_remote_state.minikube.outputs.cluster_ca_certificate
+  }
+}
+
+provider "kubectl" {
+  load_config_file       = false
+  host                   = data.terraform_remote_state.minikube.outputs.host
+  client_certificate     = data.terraform_remote_state.minikube.outputs.client_certificate
+  client_key             = data.terraform_remote_state.minikube.outputs.client_key
+  cluster_ca_certificate = data.terraform_remote_state.minikube.outputs.cluster_ca_certificate
+}
+
+resource "helm_release" "theia-cloud" {
+  name             = "theia-cloud"
+  chart            = "../../../../theia-cloud-helm/charts/theia.cloud"
+  namespace        = "theiacloud"
+  create_namespace = true
+
+  values = [
+    "${file("${path.module}/../../../helm/theia.cloud/valuesGKETryNow.yaml")}"
+  ]
+
+  set {
+    name = "hosts.usePaths"
+    # Need to hand in boolean as string as terraform converts boolean to 1 resp. 0.
+    # See https://github.com/hashicorp/terraform-provider-helm/issues/208
+    value = "true"
+  }
+
+  set {
+    name  = "hosts.paths.service"
+    value = "service"
+  }
+
+  set {
+    name  = "hosts.paths.landing"
+    value = "try"
+  }
+
+  set {
+    name  = "hosts.paths.instance"
+    value = "instances"
+  }
+
+
+  set {
+    name  = "hosts.paths.baseHost"
+    value = data.terraform_remote_state.minikube.outputs.hostname
+  }
+
+  set {
+    name  = "keycloak.authUrl"
+    value = "https://${data.terraform_remote_state.minikube.outputs.hostname}/keycloak/"
+  }
+
+  set {
+    name  = "operator.cloudProvider"
+    value = "MINIKUBE"
+  }
+
+  set {
+    name  = "ingress.clusterIssuer"
+    value = "theia-cloud-selfsigned-issuer"
+  }
+
+  set {
+    name  = "ingress.theiaCloudCommonName"
+    value = true
+  }
+
+  # Comment in to only pull missing images. This is needed to use images built locally in Minikube
+  # set {
+  #   name  = "imagePullPolicy"
+  #   value = "IfNotPresent"
+  # }
+}
+
+resource "kubectl_manifest" "cdt-cloud-demo" {
+  depends_on = [helm_release.theia-cloud]
+  yaml_body  = <<-EOF
+  apiVersion: theia.cloud/v6beta
+  kind: AppDefinition
+  metadata:
+    name: cdt-cloud-demo
+    namespace: theiacloud
+  spec:
+    downlinkLimit: 30000
+    image: theiacloud/cdt-cloud:v1.34.4
+    imagePullPolicy: IfNotPresent
+    ingressname: theia-cloud-demo-ws-ingress
+    limitsCpu: "2"
+    limitsMemory: 1200M
+    maxInstances: 10
+    minInstances: 0
+    name: cdt-cloud-demo
+    port: 3000
+    requestsCpu: 100m
+    requestsMemory: 1000M
+    timeout:
+      limit: 30
+      strategy: FIXEDTIME
+    uid: 101
+    uplinkLimit: 30000
+    mountPath: /home/project/persisted
+    monitor:
+      port: 8081
+      activityTracker:
+        timeoutAfter: 30
+        notifyAfter: 25
+  EOF
+}
+
+
+resource "kubectl_manifest" "coffee-editor" {
+  depends_on = [helm_release.theia-cloud]
+  yaml_body  = <<-EOF
+  apiVersion: theia.cloud/v6beta
+  kind: AppDefinition
+  metadata:
+    name: coffee-editor
+    namespace: theiacloud
+  spec:
+    downlinkLimit: 30000
+    image: eu.gcr.io/kubernetes-238012/coffee-editor:v0.7.17
+    imagePullPolicy: IfNotPresent
+    ingressname: theia-cloud-demo-ws-ingress
+    limitsCpu: "2"
+    limitsMemory: 2400M
+    maxInstances: 4
+    minInstances: 0
+    name: coffee-editor
+    port: 3000
+    requestsCpu: 100m
+    requestsMemory: 1000M
+    timeout:
+      limit: 30
+      strategy: FIXEDTIME
+    uid: 1001
+    uplinkLimit: 30000
+    mountPath: /home/project/persisted
+    monitor:
+      port: 8081
+      activityTracker:
+        timeoutAfter: 30
+        notifyAfter: 25
+  EOF
+}

--- a/terraform/test-configurations/2-03_try-now_paths/versions.tf
+++ b/terraform/test-configurations/2-03_try-now_paths/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14.0"
+    }
+  }
+
+  required_version = ">= 1.4.0"
+}


### PR DESCRIPTION
## Changes

- Remove hostname from app definitions
- Increase app definition spec version to v6beta
- Adapt operator to get hostname as command line parameter
- Add path-based terraform test configuration

## How to test

First, check out the corresponding branch [189-app-defs-remove-host](https://github.com/eclipsesource/theia-cloud-helm/commits/189-app-defs-remove-host) (see PR https://github.com/eclipsesource/theia-cloud-helm/pull/30) from the theia-cloud-helm repo to get the required helm changes.

Second, use one of the terraform test configurations for try now. As usual, the configuration `0_minikube-setup` and `1_theia-cloud-base` need to be installed first. Afterwards, install **one of** `2-01_try-now` or `2-03_try-now_paths`. The latter is the new config using paths.

Part of #189 

Contributed on behalf of STMicroelectronics
Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>