### PR TITLE
Fix global certificate doc to use ingressClassName

### DIFF
--- a/doc/docs/platforms/global-certificate.yaml
+++ b/doc/docs/platforms/global-certificate.yaml
@@ -40,11 +40,11 @@ kind: Ingress
 metadata:
   name: cert-deployment-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
     acme.cert-manager.io/http01-edit-in-place: "true"
     # cert-manager.io/common-name: "Theia.Cloud"
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - example.com


### PR DESCRIPTION
Related to eclipsesource/theia-cloud-helm#31

Contributed on behalf of STMicroelectronics