### PR TITLE
Detection for stuck kubernetes watchers #210

### DIFF
--- a/demo/k8s/appdefinitions/theia.yaml
+++ b/demo/k8s/appdefinitions/theia.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: theiacloud
 spec:
   downlinkLimit: 30000
-  image: theiacloud/theia-cloud-demo:0.8.1.OSWeek23-v1
+  image: theiacloud/theia-cloud-demo:0.8.1.OSWeek23-v2
   imagePullPolicy: IfNotPresent
   ingressname: theia-cloud-demo-ws-ingress
   limitsCpu: "2"

--- a/helm/theia.cloud/valuesGKETryNow.yaml
+++ b/helm/theia.cloud/valuesGKETryNow.yaml
@@ -8,7 +8,7 @@ issuer:
   email: jfaltermeier@eclipsesource.com
 
 image:
-  name: theiacloud/theia-cloud-demo:0.8.1.OSWeek23-v1
+  name: theiacloud/theia-cloud-demo:0.8.1.OSWeek23-v2
   pullSecret: ""
   timeoutStrategy: "FIXEDTIME"
   timeoutLimit: "30"
@@ -22,7 +22,7 @@ hosts:
   instance: ws.theia-cloud.io
 
 landingPage:
-  image: theiacloud/theia-cloud-try-now-page:0.8.1.OSWeek23-v1
+  image: theiacloud/theia-cloud-try-now-page:0.8.1.OSWeek23-v2
   appDefinition: "theia-cloud-demo"
   ephemeralStorage: true
   additionalApps:

--- a/helm/theia.cloud/valuesMonitor.yaml
+++ b/helm/theia.cloud/valuesMonitor.yaml
@@ -5,7 +5,7 @@ app:
   name: Theia Blueprint
 
 image:
-  name: theiacloud/theia-cloud-activity-demo:0.8.1.OSWeek23-v1
+  name: theiacloud/theia-cloud-activity-demo:0.8.1.OSWeek23-v2
   pullSecret: ""
   timeoutStrategy: "FIXEDTIME"
   timeoutLimit: "0"
@@ -20,7 +20,7 @@ hosts:
     instance: instances
 
 landingPage:
-  image: theiacloud/theia-cloud-landing-page:0.8.1.OSWeek23-v1
+  image: theiacloud/theia-cloud-landing-page:0.8.1.OSWeek23-v2
   ephemeralStorage: true
 
 keycloak:

--- a/helm/theia.cloud/valuesTestTrynowPage.yaml
+++ b/helm/theia.cloud/valuesTestTrynowPage.yaml
@@ -15,7 +15,7 @@ hosts:
   instance: ws.192.168.39.3.nip.io
 
 landingPage:
-  image: theiacloud/theia-cloud-try-now-page:0.8.1.OSWeek23-v1
+  image: theiacloud/theia-cloud-try-now-page:0.8.1.OSWeek23-v2
   imagePullPolicy: Always
   appDefinition: "theia-cloud-demo"
   ephemeralStorage: true

--- a/java/operator/org.eclipse.theia.cloud.operator/log4j2.xml
+++ b/java/operator/org.eclipse.theia.cloud.operator/log4j2.xml
@@ -15,6 +15,10 @@
 			additivity="false">
 			<AppenderRef ref="Console" />
 		</Logger>
+		<Logger name="org.eclipse.theia.cloud.operator.TheiaCloudImpl" level="info"
+			additivity="false">
+			<AppenderRef ref="Console" />
+		</Logger>
 		<Logger name="org.eclipse.theia.cloud.operator" level="trace"
 			additivity="false">
 			<AppenderRef ref="Console" />

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
@@ -110,6 +110,10 @@ public class TheiaCloudArguments {
 	    "--leaderRetryPeriod" }, description = "The retry period for the leader election in seconds.", required = false)
     private int leaderRetryPeriod = 2;
 
+    @Option(names = {
+	    "--maxWatchIdleTime" }, description = "When a kubernetes watcher is idle for more than this time (in milliseconds) we assume that there is a problem and restart.", required = false)
+    private long maxWatchIdleTime = 1000 * 60 * 60; // 1 Hour
+
     public boolean isUseKeycloak() {
 	return useKeycloak;
     }
@@ -198,6 +202,10 @@ public class TheiaCloudArguments {
 	return leaderRetryPeriod;
     }
 
+    public long getMaxWatchIdleTime() {
+	return maxWatchIdleTime;
+    }
+
     @Override
     public int hashCode() {
 	final int prime = 31;
@@ -216,6 +224,7 @@ public class TheiaCloudArguments {
 	result = prime * result + leaderLeaseDuration;
 	result = prime * result + leaderRenewDeadline;
 	result = prime * result + leaderRetryPeriod;
+	result = prime * result + (int) (maxWatchIdleTime ^ (maxWatchIdleTime >>> 32));
 	result = prime * result + ((monitorInterval == null) ? 0 : monitorInterval.hashCode());
 	result = prime * result + ((requestedStorage == null) ? 0 : requestedStorage.hashCode());
 	result = prime * result + ((serviceUrl == null) ? 0 : serviceUrl.hashCode());
@@ -282,6 +291,8 @@ public class TheiaCloudArguments {
 	    return false;
 	if (leaderRetryPeriod != other.leaderRetryPeriod)
 	    return false;
+	if (maxWatchIdleTime != other.maxWatchIdleTime)
+	    return false;
 	if (monitorInterval == null) {
 	    if (other.monitorInterval != null)
 		return false;
@@ -329,7 +340,8 @@ public class TheiaCloudArguments {
 		+ ", instancesPath=" + instancesPath + ", storageClassName=" + storageClassName + ", requestedStorage="
 		+ requestedStorage + ", keycloakURL=" + keycloakURL + ", keycloakRealm=" + keycloakRealm
 		+ ", keycloakClientId=" + keycloakClientId + ", leaderLeaseDuration=" + leaderLeaseDuration
-		+ ", leaderRenewDeadline=" + leaderRenewDeadline + ", leaderRetryPeriod=" + leaderRetryPeriod + "]";
+		+ ", leaderRenewDeadline=" + leaderRenewDeadline + ", leaderRetryPeriod=" + leaderRetryPeriod
+		+ ", maxWatchIdleTime=" + maxWatchIdleTime + "]";
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/AddedHandlerUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/AddedHandlerUtil.java
@@ -132,9 +132,30 @@ public final class AddedHandlerUtil {
 	    String url, String correlationId) {
 	EXECUTOR.execute(() -> {
 	    boolean updateURL = false;
-	    for (int i = 1; i <= 60; i++) {
+	    for (int i = 1; i <= 100; i++) {
 		try {
-		    Thread.sleep(i * 1000);
+		    /*
+		     * On the first 15 loops we will check every 2.5s whether URL is available. This
+		     * will take at least 37.5s.
+		     * 
+		     * On the second 15 loops we will check every 5s. This will take at least 75s.
+		     * 
+		     * On the next 15 loops we will check every 10s. This will take at least further
+		     * 150s.
+		     * 
+		     * If the pod has not started within the first 4-5 minutes, we will continue to
+		     * check every minute. We give up after an hour.
+		     * 
+		     */
+		    if (i <= 15) {
+			Thread.sleep(2500);
+		    } else if (i <= 30) {
+			Thread.sleep(5000);
+		    } else if (i <= 45) {
+			Thread.sleep(10000);
+		    } else {
+			Thread.sleep(60000);
+		    }
 		} catch (InterruptedException e) {
 		    /* silent */
 		}

--- a/terraform/modules/helm/theia-cloud.yaml
+++ b/terraform/modules/helm/theia-cloud.yaml
@@ -5,7 +5,7 @@ app:
   name: Theia Cloud
 
 image:
-  name: theiacloud/theia-cloud-demo:0.8.1.OSWeek23-v1
+  name: theiacloud/theia-cloud-demo:0.8.1.OSWeek23-v2
   pullSecret: ""
   timeoutStrategy: "FIXEDTIME"
   timeoutLimit: "30"
@@ -19,7 +19,7 @@ hosts:
     instance: instances
 
 landingPage:
-  image: theiacloud/theia-cloud-landing-page:0.8.1.OSWeek23-v1
+  image: theiacloud/theia-cloud-landing-page:0.8.1.OSWeek23-v2
   appDefinition: "theia-cloud-demo"
   ephemeralStorage: false
 


### PR DESCRIPTION
* extend our watchers to remember when they were last used
* add configurable timeout value where we stop the operator when watchers appear stuck
* Historically we had this issue once because of a kubernetes bug: https://github.com/eclipsesource/theia-cloud/issues/32

closes #210