### PR TITLE
#200: Crash prevention and status tracking for AppDefinitions

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazyWorkspaceHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/LazyWorkspaceHandler.java
@@ -61,7 +61,7 @@ public class LazyWorkspaceHandler implements WorkspaceHandler {
     protected boolean doWorkspaceAdded(Workspace workspace, String correlationId) {
 	LOGGER.info(formatLogMessage(correlationId, "Handling " + workspace));
 
-	// Check current session status and ignore if handling failed before
+	// Check current session status and ignore if handling failed or finished before
 	Optional<WorkspaceStatus> status = Optional.ofNullable(workspace.getStatus());
 	String operatorStatus = status.map(ResourceStatus::getOperatorStatus).orElse(OperatorStatus.NEW);
 	if (OperatorStatus.HANDLED.equals(operatorStatus)) {


### PR DESCRIPTION
Enable checking and storing of AppDefinitions' handling in the operator.

After all the existing code worked now. For reference I used commit https://github.com/eclipsesource/theia-cloud-helm/commit/20f206b4469aab8844a12a1ab6f8236dc94d317e to avoid issues with resource version incompatibilities during testing