### PR TITLE
Make version of oauth2 proxy configurable via operator param

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
@@ -218,7 +218,7 @@ public class TheiaCloudArguments {
 	return continueOnException;
     }
 
-    public String getoAuth2ProxyVersion() {
+    public String getOAuth2ProxyVersion() {
 	return oAuth2ProxyVersion;
     }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
@@ -119,8 +119,8 @@ public class TheiaCloudArguments {
     private boolean continueOnException;
 
     @Option(names = {
-	    "--oAuth2ProxyImage" }, description = "The version to use of the quay.io/oauth2-proxy/oauth2-proxy image.", required = false, defaultValue = "latest")
-    private String oAuth2ProxyImage;
+	    "--oAuth2ProxyVersion" }, description = "The version to use of the quay.io/oauth2-proxy/oauth2-proxy image.", required = false, defaultValue = "latest")
+    private String oAuth2ProxyVersion;
 
     public boolean isUseKeycloak() {
 	return useKeycloak;
@@ -218,8 +218,8 @@ public class TheiaCloudArguments {
 	return continueOnException;
     }
 
-    public String getoAuth2ProxyImage() {
-	return oAuth2ProxyImage;
+    public String getoAuth2ProxyVersion() {
+	return oAuth2ProxyVersion;
     }
 
     @Override
@@ -250,7 +250,7 @@ public class TheiaCloudArguments {
 	result = prime * result + (useKeycloak ? 1231 : 1237);
 	result = prime * result + (usePaths ? 1231 : 1237);
 	result = prime * result + ((wondershaperImage == null) ? 0 : wondershaperImage.hashCode());
-	result = prime * result + ((oAuth2ProxyImage == null) ? 0 : oAuth2ProxyImage.hashCode());
+	result = prime * result + ((oAuth2ProxyVersion == null) ? 0 : oAuth2ProxyVersion.hashCode());
 	return result;
     }
 
@@ -347,10 +347,10 @@ public class TheiaCloudArguments {
 		return false;
 	} else if (!wondershaperImage.equals(other.wondershaperImage))
 	    return false;
-	if (oAuth2ProxyImage == null) {
-	    if (other.oAuth2ProxyImage != null)
+	if (oAuth2ProxyVersion == null) {
+	    if (other.oAuth2ProxyVersion != null)
 		return false;
-	} else if (!oAuth2ProxyImage.equals(other.oAuth2ProxyImage))
+	} else if (!oAuth2ProxyVersion.equals(other.oAuth2ProxyVersion))
 	    return false;
 	return true;
     }
@@ -367,7 +367,7 @@ public class TheiaCloudArguments {
 		+ ", keycloakClientId=" + keycloakClientId + ", leaderLeaseDuration=" + leaderLeaseDuration
 		+ ", leaderRenewDeadline=" + leaderRenewDeadline + ", leaderRetryPeriod=" + leaderRetryPeriod
 		+ ", maxWatchIdleTime=" + maxWatchIdleTime + ", continueOnException=" + continueOnException
-		+ ", oAuth2ProxyImage=" + oAuth2ProxyImage + "]";
+		+ ", oAuth2ProxyVersion=" + oAuth2ProxyVersion + "]";
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/TheiaCloudArguments.java
@@ -118,6 +118,10 @@ public class TheiaCloudArguments {
 	    "--continueOnException" }, description = "Whether the operator will continue to run in case of unexpected exceptions.", required = false)
     private boolean continueOnException;
 
+    @Option(names = {
+	    "--oAuth2ProxyImage" }, description = "The version to use of the quay.io/oauth2-proxy/oauth2-proxy image.", required = false, defaultValue = "latest")
+    private String oAuth2ProxyImage;
+
     public boolean isUseKeycloak() {
 	return useKeycloak;
     }
@@ -214,6 +218,10 @@ public class TheiaCloudArguments {
 	return continueOnException;
     }
 
+    public String getoAuth2ProxyImage() {
+	return oAuth2ProxyImage;
+    }
+
     @Override
     public int hashCode() {
 	final int prime = 31;
@@ -242,6 +250,7 @@ public class TheiaCloudArguments {
 	result = prime * result + (useKeycloak ? 1231 : 1237);
 	result = prime * result + (usePaths ? 1231 : 1237);
 	result = prime * result + ((wondershaperImage == null) ? 0 : wondershaperImage.hashCode());
+	result = prime * result + ((oAuth2ProxyImage == null) ? 0 : oAuth2ProxyImage.hashCode());
 	return result;
     }
 
@@ -338,6 +347,11 @@ public class TheiaCloudArguments {
 		return false;
 	} else if (!wondershaperImage.equals(other.wondershaperImage))
 	    return false;
+	if (oAuth2ProxyImage == null) {
+	    if (other.oAuth2ProxyImage != null)
+		return false;
+	} else if (!oAuth2ProxyImage.equals(other.oAuth2ProxyImage))
+	    return false;
 	return true;
     }
 
@@ -352,7 +366,8 @@ public class TheiaCloudArguments {
 		+ requestedStorage + ", keycloakURL=" + keycloakURL + ", keycloakRealm=" + keycloakRealm
 		+ ", keycloakClientId=" + keycloakClientId + ", leaderLeaseDuration=" + leaderLeaseDuration
 		+ ", leaderRenewDeadline=" + leaderRenewDeadline + ", leaderRetryPeriod=" + leaderRetryPeriod
-		+ ", maxWatchIdleTime=" + maxWatchIdleTime + ", continueOnException=" + continueOnException + "]";
+		+ ", maxWatchIdleTime=" + maxWatchIdleTime + ", continueOnException=" + continueOnException
+		+ ", oAuth2ProxyImage=" + oAuth2ProxyImage + "]";
     }
 
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
@@ -64,7 +64,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
     public static final String PLACEHOLDER_MONITOR_PORT = "placeholder-monitor-port";
     public static final String PLACEHOLDER_MONITOR_PORT_ENV = "placeholder-monitor-env-port";
     public static final String PLACEHOLDER_ENABLE_ACTIVITY_TRACKER = "placeholder-enable-activity-tracker";
-    public static final String PLACEHOLDER_OAUTH2_PROXY_IMAGE = "placeholder-oauth2-proxy-image";
+    public static final String PLACEHOLDER_OAUTH2_PROXY_VERSION = "placeholder-oauth2-proxy-version";
 
     protected static final String DEFAULT_UID = "1000";
 
@@ -81,7 +81,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 	replacements.putAll(getAppDefinitionData(appDefinition));
 	replacements.putAll(getEnvironmentVariables(appDefinition, instance));
 	replacements.putAll(getInstanceData(appDefinition, instance));
-	replacements.put(PLACEHOLDER_OAUTH2_PROXY_IMAGE, arguments.getoAuth2ProxyImage());
+	replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getoAuth2ProxyVersion());
 	return replacements;
     }
 
@@ -92,7 +92,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 	replacements.putAll(getAppDefinitionData(appDefinition));
 	replacements.putAll(getEnvironmentVariables(appDefinition, session));
 	replacements.putAll(getSessionData(session));
-	replacements.put(PLACEHOLDER_OAUTH2_PROXY_IMAGE, arguments.getoAuth2ProxyImage());
+	replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getoAuth2ProxyVersion());
 	return replacements;
     }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
@@ -64,6 +64,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
     public static final String PLACEHOLDER_MONITOR_PORT = "placeholder-monitor-port";
     public static final String PLACEHOLDER_MONITOR_PORT_ENV = "placeholder-monitor-env-port";
     public static final String PLACEHOLDER_ENABLE_ACTIVITY_TRACKER = "placeholder-enable-activity-tracker";
+    public static final String PLACEHOLDER_OAUTH2_PROXY_IMAGE = "placeholder-oauth2-proxy-image";
 
     protected static final String DEFAULT_UID = "1000";
 
@@ -80,6 +81,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 	replacements.putAll(getAppDefinitionData(appDefinition));
 	replacements.putAll(getEnvironmentVariables(appDefinition, instance));
 	replacements.putAll(getInstanceData(appDefinition, instance));
+	replacements.put(PLACEHOLDER_OAUTH2_PROXY_IMAGE, arguments.getoAuth2ProxyImage());
 	return replacements;
     }
 
@@ -90,6 +92,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 	replacements.putAll(getAppDefinitionData(appDefinition));
 	replacements.putAll(getEnvironmentVariables(appDefinition, session));
 	replacements.putAll(getSessionData(session));
+	replacements.put(PLACEHOLDER_OAUTH2_PROXY_IMAGE, arguments.getoAuth2ProxyImage());
 	return replacements;
     }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/impl/DefaultDeploymentTemplateReplacements.java
@@ -81,7 +81,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 	replacements.putAll(getAppDefinitionData(appDefinition));
 	replacements.putAll(getEnvironmentVariables(appDefinition, instance));
 	replacements.putAll(getInstanceData(appDefinition, instance));
-	replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getoAuth2ProxyVersion());
+	replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getOAuth2ProxyVersion());
 	return replacements;
     }
 
@@ -92,7 +92,7 @@ public class DefaultDeploymentTemplateReplacements implements DeploymentTemplate
 	replacements.putAll(getAppDefinitionData(appDefinition));
 	replacements.putAll(getEnvironmentVariables(appDefinition, session));
 	replacements.putAll(getSessionData(session));
-	replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getoAuth2ProxyVersion());
+	replacements.put(PLACEHOLDER_OAUTH2_PROXY_VERSION, arguments.getOAuth2ProxyVersion());
 	return replacements;
     }
 

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -21,7 +21,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0
+          image: quay.io/oauth2-proxy/oauth2-proxy:placeholder-oauth2-proxy-image
           imagePullPolicy: Always
           args:
             - --config=/etc/oauth2-proxy.cfg

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/resources/templateDeployment.yaml
@@ -21,7 +21,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:placeholder-oauth2-proxy-image
+          image: quay.io/oauth2-proxy/oauth2-proxy:placeholder-oauth2-proxy-version
           imagePullPolicy: Always
           args:
             - --config=/etc/oauth2-proxy.cfg


### PR DESCRIPTION
This avoids always using the latest image.
For example if there are breaking changes.
Defaults to latest.

Linked helm repo PR: https://github.com/eclipsesource/theia-cloud-helm/pull/44
To test build the operator, create a deployment using the helm chart from the link above and make sure to use keycloak.
When creating a session, the pod should contain the oauth2 proxy with the version you specified in the helm chart.

Note: This was originally brought up, because we had issues with the 7.5.0 version of the oauth2 proxy. I can however, no longer reproduce them. So testing any reasonably new version should work.
