### PR TITLE
Update outdated base images and release 0.8.1.MS3

### DIFF
--- a/demo/dockerfiles/demo-theia-monitor-theia/Dockerfile
+++ b/demo/dockerfiles/demo-theia-monitor-theia/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye as build-stage
+FROM node:16-bookworm as build-stage
 RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev
 WORKDIR /home/theia
 ADD package.json ./package.json
@@ -13,10 +13,11 @@ RUN yarn --pure-lockfile && \
     yarn autoclean --force && \
     yarn cache clean
 
-FROM node:16-bullseye-slim as production-stage
+FROM node:16-bookworm-slim as production-stage
 RUN adduser --system --group theia
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \
+    mkdir -p /home/theia && \
     chown -R theia:theia /home/theia && \
     chown -R theia:theia /home/project;
 RUN apt-get update && apt-get install -y wget apt-transport-https && \

--- a/demo/dockerfiles/demo-theia-monitor-vscode/Dockerfile
+++ b/demo/dockerfiles/demo-theia-monitor-vscode/Dockerfile
@@ -1,3 +1,3 @@
-FROM theiacloud/theia-cloud-demo as production-stage
+FROM theiacloud/theia-cloud-demo:0.8.1.MS3 as production-stage
 
 COPY --chown=theia:theia theiacloud-monitor-0.8.1.vsix /home/theia/applications/browser/plugins

--- a/demo/k8s/appdefinitions/theia.yaml
+++ b/demo/k8s/appdefinitions/theia.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: theiacloud
 spec:
   downlinkLimit: 30000
-  image: theiacloud/theia-cloud-demo:0.8.1.MS2
+  image: theiacloud/theia-cloud-demo:0.8.1.MS3
   imagePullPolicy: IfNotPresent
   ingressname: theia-cloud-demo-ws-ingress
   limitsCpu: "2"

--- a/dockerfiles/operator/Dockerfile
+++ b/dockerfiles/operator/Dockerfile
@@ -1,4 +1,5 @@
-FROM maven:3.8.4-openjdk-11 AS builder
+FROM eclipse-temurin:11-jdk AS builder
+RUN apt-get update && apt-get install -y maven
 WORKDIR /operator
 COPY java/common ./common
 COPY java/operator ./operator
@@ -9,7 +10,7 @@ RUN cd /operator/common/maven-conf && \
     cd /operator/operator/org.eclipse.theia.cloud.operator && \
     mvn clean verify --no-transfer-progress
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-alpine
 RUN mkdir /templates
 WORKDIR /log-config
 COPY java/operator/org.eclipse.theia.cloud.operator/log4j2.xml .

--- a/dockerfiles/operator/Dockerfile.withcache
+++ b/dockerfiles/operator/Dockerfile.withcache
@@ -1,4 +1,5 @@
-FROM maven:3.8.4-openjdk-11 AS builder
+FROM eclipse-temurin:11-jdk AS builder
+RUN apt-get update && apt-get install -y maven
 WORKDIR /operator
 COPY java/common ./common
 COPY java/operator ./operator
@@ -10,7 +11,7 @@ RUN --mount=type=cache,target=/root/.m2 \
     cd /operator/operator/org.eclipse.theia.cloud.operator && \
     mvn clean verify
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-alpine
 RUN mkdir /templates
 WORKDIR /log-config
 COPY java/operator/org.eclipse.theia.cloud.operator/log4j2.xml .

--- a/dockerfiles/service/Dockerfile
+++ b/dockerfiles/service/Dockerfile
@@ -1,4 +1,5 @@
-FROM maven:3.8.4-openjdk-11 AS builder
+FROM eclipse-temurin:11-jdk AS builder
+RUN apt-get update && apt-get install -y maven
 WORKDIR /service
 COPY java/common ./common
 COPY java/service ./service
@@ -9,7 +10,7 @@ RUN cd /service/common/maven-conf && \
     cd /service/service/org.eclipse.theia.cloud.service && \
     mvn clean package -Dmaven.test.skip=true -Dquarkus.package.type=uber-jar --no-transfer-progress
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-alpine
 WORKDIR /service
 COPY --from=builder /service/service/org.eclipse.theia.cloud.service/target/service-0.8.1-SNAPSHOT-runner.jar .
 ENV APPID default-app-id

--- a/dockerfiles/service/Dockerfile.withcache
+++ b/dockerfiles/service/Dockerfile.withcache
@@ -1,4 +1,5 @@
-FROM maven:3.8.4-openjdk-11 AS builder
+FROM eclipse-temurin:11-jdk AS builder
+RUN apt-get update && apt-get install -y maven
 WORKDIR /service
 COPY java/common ./common
 COPY java/service ./service
@@ -10,7 +11,7 @@ RUN --mount=type=cache,target=/root/.m2 \
     cd /service/service/org.eclipse.theia.cloud.service && \
     mvn clean package -Dmaven.test.skip=true -Dquarkus.package.type=uber-jar
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-alpine
 WORKDIR /service
 COPY --from=builder /service/service/org.eclipse.theia.cloud.service/target/service-0.8.1-SNAPSHOT-runner.jar .
 ENV APPID default-app-id

--- a/dockerfiles/wondershaper/Dockerfile
+++ b/dockerfiles/wondershaper/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y iproute2 wondershaper && \
     apt-get clean
 # kilobits per second

--- a/helm/theia.cloud/valuesGKETryNow.yaml
+++ b/helm/theia.cloud/valuesGKETryNow.yaml
@@ -8,7 +8,7 @@ issuer:
   email: jfaltermeier@eclipsesource.com
 
 image:
-  name: theiacloud/theia-cloud-demo:0.8.1.MS2
+  name: theiacloud/theia-cloud-demo:0.8.1.MS3
   pullSecret: ""
   timeoutStrategy: "FIXEDTIME"
   timeoutLimit: "30"
@@ -22,7 +22,7 @@ hosts:
   instance: ws.theia-cloud.io
 
 landingPage:
-  image: theiacloud/theia-cloud-try-now-page:0.8.1.MS2
+  image: theiacloud/theia-cloud-try-now-page:0.8.1.MS3
   appDefinition: "theia-cloud-demo"
   ephemeralStorage: true
   additionalApps:

--- a/helm/theia.cloud/valuesMonitor.yaml
+++ b/helm/theia.cloud/valuesMonitor.yaml
@@ -5,7 +5,7 @@ app:
   name: Theia Blueprint
 
 image:
-  name: theiacloud/theia-cloud-activity-demo:0.8.1.MS2
+  name: theiacloud/theia-cloud-activity-demo:0.8.1.MS3
   pullSecret: ""
   timeoutStrategy: "FIXEDTIME"
   timeoutLimit: "0"
@@ -19,7 +19,7 @@ hosts:
   instance: ws.theia-cloud.io
 
 landingPage:
-  image: theiacloud/theia-cloud-try-now-page:0.8.1.MS2
+  image: theiacloud/theia-cloud-try-now-page:0.8.1.MS3
   appDefinition: "theia-cloud-demo"
   ephemeralStorage: true
 

--- a/helm/theia.cloud/valuesTestTrynowPage.yaml
+++ b/helm/theia.cloud/valuesTestTrynowPage.yaml
@@ -15,7 +15,7 @@ hosts:
   instance: ws.192.168.39.3.nip.io
 
 landingPage:
-  image: theiacloud/theia-cloud-try-now-page:0.8.1.MS2
+  image: theiacloud/theia-cloud-try-now-page:0.8.1.MS3
   imagePullPolicy: Always
   appDefinition: "theia-cloud-demo"
   ephemeralStorage: true

--- a/terraform/modules/helm/main.tf
+++ b/terraform/modules/helm/main.tf
@@ -130,7 +130,7 @@ resource "helm_release" "theia-cloud-base" {
   name             = "theia-cloud-base"
   repository       = "https://github.eclipsesource.com/theia-cloud-helm"
   chart            = "theia-cloud-base"
-  version          = "0.8.1-v004-MS2"
+  version          = "0.8.1-v004-MS3"
   namespace        = "theiacloud"
   create_namespace = true
 
@@ -145,7 +145,7 @@ resource "helm_release" "theia-cloud-crds" {
   name             = "theia-cloud-crds"
   repository       = "https://github.eclipsesource.com/theia-cloud-helm"
   chart            = "theia-cloud-crds"
-  version          = "0.8.1-v004-MS2"
+  version          = "0.8.1-v004-MS3"
   namespace        = "theiacloud"
   create_namespace = true
 }
@@ -162,9 +162,9 @@ locals {
   # it will output "".
   local_exec_quotes = startswith(abspath(path.module), "/") ? "'" : ""
   jsonpatch = jsonencode([{
-      "op" = "add",
-      "path" = "/spec/template/spec/containers/0/args/-",
-      "value" = "--default-ssl-certificate=keycloak/${var.hostname}-tls"
+    "op"    = "add",
+    "path"  = "/spec/template/spec/containers/0/args/-",
+    "value" = "--default-ssl-certificate=keycloak/${var.hostname}-tls"
   }])
 }
 
@@ -229,7 +229,7 @@ resource "helm_release" "theia-cloud" {
   name             = "theia-cloud"
   repository       = "https://github.eclipsesource.com/theia-cloud-helm"
   chart            = "theia-cloud"
-  version          = "0.8.1-v008-MS2"
+  version          = "0.8.1-v009-MS3"
   namespace        = "theiacloud"
   create_namespace = true
 

--- a/terraform/modules/helm/theia-cloud.yaml
+++ b/terraform/modules/helm/theia-cloud.yaml
@@ -5,7 +5,7 @@ app:
   name: Theia Cloud
 
 image:
-  name: theiacloud/theia-cloud-demo:0.8.1.MS2
+  name: theiacloud/theia-cloud-demo:0.8.1.MS3
   pullSecret: ""
   timeoutStrategy: "FIXEDTIME"
   timeoutLimit: "30"
@@ -19,7 +19,7 @@ hosts:
     instance: instances
 
 landingPage:
-  image: theiacloud/theia-cloud-landing-page:0.8.1.MS2
+  image: theiacloud/theia-cloud-landing-page:0.8.1.MS3
   appDefinition: "theia-cloud-demo"
   ephemeralStorage: false
 

--- a/terraform/test-configurations/2-02_monitor/theia_cloud.tf
+++ b/terraform/test-configurations/2-02_monitor/theia_cloud.tf
@@ -77,7 +77,7 @@ resource "helm_release" "theia-cloud" {
 
   set {
     name  = "image.name"
-    value = var.use_vscode_extension ? "theiacloud/theia-cloud-activity-demo:0.8.1.MS2" : "theiacloud/theia-cloud-activity-demo-theia:0.8.1.MS2"
+    value = var.use_vscode_extension ? "theiacloud/theia-cloud-activity-demo:0.8.1.MS3" : "theiacloud/theia-cloud-activity-demo-theia:0.8.1.MS3"
   }
 
   set {


### PR DESCRIPTION
## 0.8.1.MS3

To test this, use the helm chart from https://github.com/eclipsesource/theia-cloud-helm/pull/44 as this is configured to use MS3.

Images with tag `0.8.1.MS3` are already pushed to [Dockerhub](https://hub.docker.com/u/theiacloud). I'll push a git tag for the release after the PR is merged. New image were built with docker's `--pull` flag to get the latest base images.

## Update outdated base images 

- Move from openjdk buster images as Java runtimes to Eclipse Temurin Alpine images
- Use Eclipse Temurin images as JDK builder images
- Update the monitor demo and wondershaper images to use Debian bookworm instead of bullseye