### PR TITLE
Rename publish npm script to avoid rerun of publish

### DIFF
--- a/.github/workflows/reusable-npm.yml
+++ b/.github/workflows/reusable-npm.yml
@@ -76,6 +76,6 @@ jobs:
         run: npm ci
 
       - name: Publish new version and latest
-        run: npm run publish -w ${{ inputs.package_workspace }}
+        run: npm run publish:latest -w ${{ inputs.package_workspace }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}

--- a/node/common/package.json
+++ b/node/common/package.json
@@ -34,7 +34,7 @@
     "build": "tsc",
     "prepublishOnly": "npm run build",
     "publish:next": "npm version `npm pkg get version | tr -d '\"'`.`git rev-parse --short HEAD` && npm publish --tag next",
-    "publish": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {
     "@types/uuid": "^8.3.4",

--- a/node/monitor-theia/package.json
+++ b/node/monitor-theia/package.json
@@ -23,7 +23,7 @@
     "watch": "tsc -w",
     "prepublishOnly": "npm run build",
     "publish:next": "npm version `npm pkg get version | tr -d '\"'`.`git rev-parse --short HEAD` && npm publish --tag next",
-    "publish": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest"
   },
   "theiaExtensions": [
     {


### PR DESCRIPTION
_Small fix to fix failing builds: https://github.com/eclipsesource/theia-cloud/actions/runs/7140492012. Artifacts have been published correctly though. So no rerun is necessary._

Renamed publish script to publish:latest.
Before the script was executed everytime we ran npm publish. 
This then fails because you cannot publish the same version twice. 
Also prevents the latest tag to be applied on next publish. Also it probably would have ended in a loop.

Contributed on behalf of STMicroelectronics