### PR TITLE
Make sure publish:next is executed for workflow changes

### DIFF
--- a/.github/workflows/ci-landing-page.yml
+++ b/.github/workflows/ci-landing-page.yml
@@ -8,6 +8,9 @@ on:
       - "node/common/**"
       - "node/landing-page/**"
       - "dockerfiles/landing-page/**"
+      # Publish when a workflow has changed (this is needed to detect version updates)
+      - ".github/workflows/ci-landing-page.yml"
+      - ".github/workflows/reuseable-docker.yml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-monitor-theia.yml
+++ b/.github/workflows/ci-monitor-theia.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - "node/monitor-theia/**"
+      # Publish when a workflow has changed (this is needed to detect version updates)
+      - ".github/workflows/ci-monitor-theia.yml"
+      - ".github/workflows/reuseable-npm.yml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-node-common.yml
+++ b/.github/workflows/ci-node-common.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - "node/common/**"
+      # Publish when a workflow has changed (this is needed to detect version updates)
+      - ".github/workflows/ci-node-common.yml"
+      - ".github/workflows/reuseable-npm.yml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-operator.yml
+++ b/.github/workflows/ci-operator.yml
@@ -8,6 +8,9 @@ on:
       - "java/common/**"
       - "java/operator/**"
       - "dockerfiles/operator/**"
+      # Publish when a workflow has changed (this is needed to detect version updates)
+      - ".github/workflows/ci-operator.yml"
+      - ".github/workflows/reuseable-docker.yml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -8,6 +8,9 @@ on:
       - "java/common/**"
       - "java/service/**"
       - "dockerfiles/service/**"
+      # Publish when a workflow has changed (this is needed to detect version updates)
+      - ".github/workflows/ci-service.yml"
+      - ".github/workflows/reuseable-docker.yml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-try-now-page.yml
+++ b/.github/workflows/ci-try-now-page.yml
@@ -8,6 +8,9 @@ on:
       - "node/common/**"
       - "node/try-now-page/**"
       - "dockerfiles/try-now-page/**"
+      # Publish when a workflow has changed (this is needed to detect version updates)
+      - ".github/workflows/ci-try-now-page.yml"
+      - ".github/workflows/reuseable-docker.yml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-wondershaper.yml
+++ b/.github/workflows/ci-wondershaper.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - "dockerfiles/wondershaper/**"
+      # Publish when a workflow has changed (this is needed to detect version updates)
+      - ".github/workflows/ci-wondershaper.yml"
+      - ".github/workflows/reuseable-docker.yml"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Beforehand, for example, the wondershaper image was not published, when the version changed. 
This is because, the version is just changed in the workflow and not the dockerfiles. 
Therefore we should make sure to also publish the next versions if only the workflows changed.

Contributed on behalf of STMicroelectronics

Note: We could theoretically only do this for the wondershaper ci, but i think this makes it clearer and more robust against future changes for the other build. Also i decided against building on the PR for workflow changes, as only workflow changes should not alter the build of the applications.