### PR TITLE
Fix user id to 101 in demo monitor theia image to match app definition

### DIFF
--- a/demo/dockerfiles/demo-theia-monitor-theia/Dockerfile
+++ b/demo/dockerfiles/demo-theia-monitor-theia/Dockerfile
@@ -23,7 +23,9 @@ RUN yarn --pure-lockfile && \
     yarn cache clean
 
 FROM node:20-bookworm-slim as production-stage
-RUN adduser --system --group theia
+
+# Use fixed user id 101 to guarantee it matches the app definition
+RUN adduser --system --group --uid 101 theia
 RUN chmod g+rw /home && \
     mkdir -p /home/project && \
     mkdir -p /home/theia && \


### PR DESCRIPTION
Note that a higher user id (e.g. 200) would likely be more consistent because installed system service (e.g. systemd-*, sshd) also use users with 10x user ids.
However, the base image for the demo theia and demo monitor vscode both use the `ghcr.io/eclipse-theia/theia-blueprint/theia-ide` base images with a preconfigured `theia` user that by chance uses user id `101`. To keep all three demo images consistent, also use 101 for the demo monitor theia image.

If we want to use a higher id, we need to adapt the base image https://github.com/eclipse-theia/theia-blueprint/blob/master/browser.Dockerfile first 