### PR TITLE
Add WebView Support #296

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Extend configuration options for the new landing page for texts and logo file type
   - Removed terms and conditions
   - Build the common package as ESM and CJS bundles for extended compatibility
+- [common] Add `ingressHostnamePrefixes` list to `AppDefinition.v1beta10` [#298](https://github.com/eclipsesource/theia-cloud/pull/298) | [#57](https://github.com/eclipsesource/theia-cloud-helm/pull/57)
 
 ## [0.10.0] - 2024-04-02
 

--- a/documentation/LocalCertificates.md
+++ b/documentation/LocalCertificates.md
@@ -1,0 +1,11 @@
+# Installing the self signed CA for local testing
+
+When testing locally you usually have to accept the self signed certificate in your browser. When working with wildcard certificates however, as used by e.g. the default webview hostnames, you usually will get an error with no way to accept the certificate.
+
+You may import the self-signed CA in your browser however. You may export the secret to an importable file like this:
+
+```bash
+kubectl get secret theia-cloud-ca-key-pair -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 --decode > ca.crt
+```
+
+Then, e.g. in Chrome, got to <chrome://settings/certificates> and Add Authority.

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/appdefinition/AppDefinitionSpec.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/appdefinition/AppDefinitionSpec.java
@@ -16,6 +16,7 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.common.k8s.resource.appdefinition;
 
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.hub.AppDefinitionHub;
@@ -83,6 +84,9 @@ public class AppDefinitionSpec {
     @JsonProperty("options")
     private Map<String, String> options;
 
+    @JsonProperty("ingressHostnamePrefixes")
+    private List<String> ingressHostnamePrefixes;
+
     /**
      * Default constructor.
      */
@@ -110,6 +114,7 @@ public class AppDefinitionSpec {
 	this.timeout = fromHub.getTimeoutLimit().orElse(0);
 
 	this.options = fromHub.getOptions().orElse(null);
+	this.ingressHostnamePrefixes = fromHub.getIngressHostnamePrefixes().orElse(null);
 
 	int monitorPort = fromHub.getMonitorPort().orElse(0);
 	if (monitorPort > 0) {
@@ -199,6 +204,10 @@ public class AppDefinitionSpec {
 
     public Map<String, String> getOptions() {
 	return options;
+    }
+
+    public List<String> getIngressHostnamePrefixes() {
+	return ingressHostnamePrefixes;
     }
 
     @Override

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/appdefinition/hub/AppDefinitionHub.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/k8s/resource/appdefinition/hub/AppDefinitionHub.java
@@ -15,6 +15,7 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.common.k8s.resource.appdefinition.hub;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -42,6 +43,7 @@ public class AppDefinitionHub {
     final OptionalInt downlinkLimit;// kilobits per second
     final OptionalInt uplinkLimit;// kilobits per second
     final Optional<String> mountPath;
+    final Optional<List<String>> ingressHostnamePrefixes;
 
     final OptionalInt timeoutLimit;
     @Deprecated
@@ -75,6 +77,7 @@ public class AppDefinitionHub {
 	this.uplinkLimit = OptionalInt.of(toHub.getSpec().getUplinkLimit());
 	this.mountPath = Optional.ofNullable(toHub.getSpec().getMountPath());
 	this.options = Optional.ofNullable(toHub.getSpec().getOptions());
+	this.ingressHostnamePrefixes = Optional.ofNullable(toHub.getSpec().getIngressHostnamePrefixes());
 
 	this.timeoutLimit = OptionalInt.of(toHub.getSpec().getTimeout());
 
@@ -126,6 +129,7 @@ public class AppDefinitionHub {
 	this.uplinkLimit = OptionalInt.of(toHub.getSpec().getUplinkLimit());
 	this.mountPath = Optional.ofNullable(toHub.getSpec().getMountPath());
 	this.options = Optional.empty();
+	this.ingressHostnamePrefixes = Optional.empty();
 
 	this.timeoutLimit = OptionalInt.of(toHub.getSpec().getTimeout());
 
@@ -177,6 +181,7 @@ public class AppDefinitionHub {
 	this.uplinkLimit = OptionalInt.of(toHub.getSpec().getUplinkLimit());
 	this.mountPath = Optional.ofNullable(toHub.getSpec().getMountPath());
 	this.options = Optional.empty();
+	this.ingressHostnamePrefixes = Optional.empty();
 
 	if (toHub.getSpec().getTimeout() != null) {
 	    this.timeoutLimit = OptionalInt.of(toHub.getSpec().getTimeout().getLimit());
@@ -311,6 +316,10 @@ public class AppDefinitionHub {
 
     public Optional<Map<String, String>> getOptions() {
 	return options;
+    }
+
+    public Optional<List<String>> getIngressHostnamePrefixes() {
+	return ingressHostnamePrefixes;
     }
 
 }


### PR DESCRIPTION
* add ingressHostnamePrefixes to AppDefinition. This is a list that makes sures that these additional prefixes to the specified hostname will also be added in the ingress. This is a property of the AppDefinition since this can be configured on Theia side and may vary between app definitions. 
* update ingress rules accordingly with additional values from ingressHostnamePrefixes

also see https://github.com/eclipsesource/theia-cloud-helm/pull/57

Closes #296

Testing is easiest with the sub domain based Theia Cloud version, since this one generates all certificates itself. 

Our path based minikube test version is configured to reuse the same certificate as generated for keycloak. 
We added the `hosts.paths.tlsSecretName` value, which allows to provide fitting certificates via the secrets for each ingress (manually if needed). 
This + the `ingress.certManagerAnnotations` allows the user to specify the certificates on a (remote) cluster, even without the cert manager. 

For getting wildcard certificates from cert-manager we need to configure a DNS01 challenge: https://cert-manager.io/docs/configuration/acme/dns01/
Depending on the DNS provider this requires different configuration, so we cannot really provide a default here. 

In the short run being able to provide the tls cert via a secret should be enough to get it working on all providers. 
In the long run we have to extend our documentation and maybe the helm values/templates as we learn more about how people want to configure this. 

**Testing instructions:**

WebView VSIX can be created with these two projects:
WebView Sample: https://github.com/microsoft/vscode-extension-samples/tree/main/webview-sample
WebView based EDitor Sample: https://github.com/microsoft/vscode-extension-samples/tree/main/custom-editor-sample

* Check out this branch and https://github.com/eclipsesource/theia-cloud-helm/pull/57

* Build the docker images

* Local Testing / Sub Domain Based Theia Cloud
  * start 2-01_try-now test configuration
  * export the CA certificate:
    * `kubectl get secret theia-cloud-ca-key-pair -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 --decode > ca.crt`
  * Go to chrome://settings/certificates -> Authorities -> Import -> Select ca.crt -> Trust for identifying websites
  * Go to Theia Cloud Landing Page
    * (Accept Keycloak Certificate warning, if any)
  * Start a session, upload a vsix with a webview sample via drag and drop
  * Test WebViews
    * You may also check the ingress yaml to see the added paths 
  * Shutdown 2-01_try-now
  
* Test that the `hosts.paths.tlsSecretName` and `ingress.certManagerAnnotations` are working. With these options all use cases should be possible, since we may provide own tls secrets (without cert-manager if required)

* Testing paths can be done like this (it's a bit messy, since multiple ingresses requests certs for the base domain, and I think the keycloak one wins, since it's the first one. However for the webviews the right cert is used so that it can be tested. )
  * Open 2-03_try-now_paths/theia_cloud.tf and add `set { name  = "hosts.paths.tlsSecretName" value = true }`
  * start 2-03_try-now_paths
  * export the CA certificate:
    * `kubectl get secret theia-cloud-ca-key-pair -n cert-manager -o jsonpath='{.data.tls\.crt}' | base64 --decode > ca.crt`
  * Go to chrome://settings/certificates -> Authorities -> Import -> Select ca.crt -> Trust for identifying websites
  * Go to Theia Cloud Landing Page
    * (Accept Certificates if any. I think the landing page may get one that was generated for keycloak, so above CA is not used)
  * Start a session, upload a vsix with a webview sample via drag and drop
  * Test WebViews
    * You may also check the ingress yaml to see the added paths 
  * Shutdown 2-03_try-now_paths

For more testing see this WIP documentation about custom certificates and how to create wildcard certificates with Let's encrypt manually: https://github.com/eclipsesource/theia-cloud-website/pull/32 https://deploy-preview-32--theia-cloud.netlify.app/documentation/moredocumentation/#custom-certificates