### PR TITLE
Rework CI workflow names

### DIFF
--- a/.github/workflows/ci-conversion-webhook.yml
+++ b/.github/workflows/ci-conversion-webhook.yml
@@ -1,4 +1,4 @@
-name: conversion-webhook CI
+name: "[DOCKER] conversion-webhook"
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
       - published
 
 jobs:
-  call-reusable-docker-workflow:
+  run:
     uses: ./.github/workflows/reusable-docker.yml
     with:
       docker_org: theiacloud

--- a/.github/workflows/ci-landing-page.yml
+++ b/.github/workflows/ci-landing-page.yml
@@ -1,4 +1,4 @@
-name: Landing Page CI
+name: "[DOCKER] landing-page"
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
       - published
 
 jobs:
-  call-reusable-docker-workflow:
+  run:
     uses: ./.github/workflows/reusable-docker.yml
     with:
       docker_org: theiacloud

--- a/.github/workflows/ci-maven-common.yml
+++ b/.github/workflows/ci-maven-common.yml
@@ -1,4 +1,4 @@
-name: Maven org.eclipse.theia.cloud.common CI
+name: "[MAVEN] common"
 
 on:
   push:
@@ -16,7 +16,7 @@ on:
       - published
 
 jobs:
-  call-reusable-maven-workflow:
+  run:
     permissions:
       packages: write
     uses: ./.github/workflows/reusable-maven.yml

--- a/.github/workflows/ci-maven-conf.yml
+++ b/.github/workflows/ci-maven-conf.yml
@@ -1,4 +1,4 @@
-name: Maven config CI
+name: "[MAVEN] maven-conf"
 
 on:
   push:
@@ -16,7 +16,7 @@ on:
       - published
 
 jobs:
-  call-reusable-maven-workflow:
+  run:
     permissions:
       packages: write
     uses: ./.github/workflows/reusable-maven.yml

--- a/.github/workflows/ci-maven-operator.yml
+++ b/.github/workflows/ci-maven-operator.yml
@@ -1,4 +1,4 @@
-name: Maven org.eclipse.theia.cloud.operator CI
+name: "[MAVEN] operator"
 
 on:
   push:
@@ -18,7 +18,7 @@ on:
       - published
 
 jobs:
-  call-reusable-maven-workflow:
+  run:
     permissions:
       packages: write
     uses: ./.github/workflows/reusable-maven.yml

--- a/.github/workflows/ci-maven-service.yml
+++ b/.github/workflows/ci-maven-service.yml
@@ -1,4 +1,4 @@
-name: Maven org.eclipse.theia.cloud.service CI
+name: "[MAVEN] service"
 on:
   push:
     branches:
@@ -17,7 +17,7 @@ on:
       - published
 
 jobs:
-  call-reusable-maven-workflow:
+  run:
     permissions:
       packages: write
     uses: ./.github/workflows/reusable-maven.yml

--- a/.github/workflows/ci-monitor-theia.yml
+++ b/.github/workflows/ci-monitor-theia.yml
@@ -1,4 +1,4 @@
-name: Monitor Theia extension CI
+name: "[NPM] monitor-theia"
 
 on:
   push:
@@ -19,7 +19,7 @@ on:
       - published
 
 jobs:
-  call-reusable-npm-workflow:
+  run:
     uses: ./.github/workflows/reusable-npm.yml
     with:
       package_workspace: monitor-theia

--- a/.github/workflows/ci-node-common.yml
+++ b/.github/workflows/ci-node-common.yml
@@ -1,4 +1,4 @@
-name: Common node package CI
+name: "[NPM] common"
 
 on:
   push:
@@ -19,7 +19,7 @@ on:
       - published
 
 jobs:
-  call-reusable-npm-workflow:
+  run:
     uses: ./.github/workflows/reusable-npm.yml
     with:
       package_workspace: common

--- a/.github/workflows/ci-operator.yml
+++ b/.github/workflows/ci-operator.yml
@@ -1,4 +1,4 @@
-name: Operator CI
+name: "[DOCKER] operator"
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
       - published
 
 jobs:
-  call-reusable-docker-workflow:
+  run:
     uses: ./.github/workflows/reusable-docker.yml
     with:
       docker_org: theiacloud

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -1,4 +1,4 @@
-name: Service CI
+name: "[DOCKER] service"
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
       - published
 
 jobs:
-  call-reusable-docker-workflow:
+  run:
     uses: ./.github/workflows/reusable-docker.yml
     with:
       docker_org: theiacloud

--- a/.github/workflows/ci-wondershaper.yml
+++ b/.github/workflows/ci-wondershaper.yml
@@ -1,4 +1,4 @@
-name: Wondershaper CI
+name: "[DOCKER] wondershaper"
 
 on:
   push:
@@ -19,7 +19,7 @@ on:
       - published
 
 jobs:
-  call-reusable-docker-workflow:
+  run:
     uses: ./.github/workflows/reusable-docker.yml
     with:
       docker_org: theiacloud

--- a/.github/workflows/publish-demos.yml
+++ b/.github/workflows/publish-demos.yml
@@ -1,4 +1,4 @@
-name: Publish Demos CI
+name: "[DOCKER] demos"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/reusable-demo.yml
+++ b/.github/workflows/reusable-demo.yml
@@ -1,4 +1,4 @@
-name: Reusable workflow publishing demo applications
+name: Reusable workflow for demo applications
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -39,80 +39,65 @@ jobs:
         run: |
           docker build -t ${{ steps.get_tags.outputs.version_tag }} -f ${{ inputs.docker_file }} .
 
-  check-version:
+  publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    outputs:
-      is_next_version: ${{ steps.version_check.outputs.is_next_version }}
+    if: github.event_name == 'push' || github.event_name == 'release'
     steps:
-      - id: version_check
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # Check if we have a valid *-next version for merges on main
+      - name: Check version (only for push events)
+        if: github.event_name == 'push'
+        id: version_check
         run: |
           if [[ $VERSION == *"-next" ]]; then
             echo "is_next_version=true" >> $GITHUB_OUTPUT
           else
             echo "is_next_version=false" >> $GITHUB_OUTPUT
-          fi
 
-  publish-next:
-    runs-on: ubuntu-latest
-    needs: check-version
-    if: github.event_name == 'push' && needs.check-version.outputs.is_next_version == 'true'
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
+      # Create tags according to the state to be published:
+      # - next version on main merge: create `*-next` and `*-next.<git_sha>` tags
+      # - release version: create version, `*-next` and `latest` tags
       - name: Create docker tags
         id: get_tags
+        if: github.event_name == 'push' && steps.version_check.outputs.is_next_version == 'true' || github.event_name == 'release'
         run: |
-          echo "sha_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}.$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
-          echo "version_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+            echo "sha_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}.$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
+            echo "version_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          else
+            echo "version_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}" >> $GITHUB_OUTPUT
+            echo "next_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}-next" >> $GITHUB_OUTPUT
+            echo "latest_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:latest" >> $GITHUB_OUTPUT
 
+      # Only build when we will publish, so either a main merge with next-version or a release
       - name: Build Docker image
+        if: github.event_name == 'push' && steps.version_check.outputs.is_next_version == 'true' || github.event_name == 'release'
         run: docker build -t ${{ steps.get_tags.outputs.version_tag }} -f ${{ inputs.docker_file }} .
 
+      # Only log in to dockerhub when we will publish, so either a main merge with next-version or a release
       - name: Login to DockerHub
+        if: github.event_name == 'push' && steps.version_check.outputs.is_next_version == 'true' || github.event_name == 'release'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.dockerhub_username }}
           password: ${{ secrets.dockerhub_token }}
 
-      # Push version and SHA tag for main pushes of next versions (This avoids duplicate pushes for release commits on main)
-      - name: Push version and SHA tag
+      # Push for main merges with next version
+      - name: Push Docker tags (for push events with next version)
+        if: github.event_name == 'push' && steps.version_check.outputs.is_next_version == 'true'
         run: |
           docker push ${{ steps.get_tags.outputs.version_tag }}
           docker tag ${{ steps.get_tags.outputs.version_tag }} ${{ steps.get_tags.outputs.sha_tag }}
           docker push ${{ steps.get_tags.outputs.sha_tag }}
 
-  publish-latest:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Create docker tags
-        id: get_tags
-        run: |
-          echo "version_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}" >> $GITHUB_OUTPUT
-          echo "next_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}-next" >> $GITHUB_OUTPUT
-          echo "latest_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:latest" >> $GITHUB_OUTPUT
-
-      - name: Build Docker image
-        run: docker build -t ${{ steps.get_tags.outputs.version_tag }} -f ${{ inputs.docker_file }} .
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.dockerhub_username }}
-          password: ${{ secrets.dockerhub_token }}
-
-      # Push version, next and latest tag for releases (version should be valid semver)
-      - name: Push version and latest tag
+      # Push for releases
+      - name: Push Docker tags (for release events)
+        if: github.event_name == 'release'
         run: |
           docker push ${{ steps.get_tags.outputs.version_tag }}
           docker tag ${{ steps.get_tags.outputs.version_tag }} ${{ steps.get_tags.outputs.latest_tag }}
           docker push ${{ steps.get_tags.outputs.latest_tag }}
-          docker tag ${{ steps.get_tags.outputs.version_tag }} ${{ steps.get_tags.outputs.next_tag }} 
+          docker tag ${{ steps.get_tags.outputs.version_tag }} ${{ steps.get_tags.outputs.next_tag }}
           docker push ${{ steps.get_tags.outputs.next_tag }}

--- a/.github/workflows/reusable-maven.yml
+++ b/.github/workflows/reusable-maven.yml
@@ -46,14 +46,13 @@ jobs:
           cd ${{ inputs.path_to_package }}
           mvn verify -fae --no-transfer-progress
 
-  check-version:
+  publish:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'release'
-    outputs:
-      is_snapshot_version: ${{ steps.version_check.outputs.is_snapshot_version }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
       - id: version_check
         run: |
           cd ${{ inputs.path_to_package }}
@@ -62,25 +61,24 @@ jobs:
             echo "is_snapshot_version=true" >> $GITHUB_OUTPUT
           else
             echo "is_snapshot_version=false" >> $GITHUB_OUTPUT
-          fi
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: check-version
-    if: (github.event_name == 'push' && needs.check-version.outputs.is_snapshot_version == 'true') || (github.event_name == 'release' && needs.check-version.outputs.is_snapshot_version == 'false')
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
+      # Only continue from here when the version matches the event, so either:
+      # - main merge with snapshot version
+      # - release with proper version
       - name: Set up JDK 17
+        if: |
+          (github.event_name == 'push' && steps.version_check.outputs.is_snapshot_version == 'true') || 
+          (github.event_name == 'release' && steps.version_check.outputs.is_snapshot_version == 'false')
         uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Build dependencies
-        if: ${{ inputs.dependencies != '' }}
+        if: |
+          ${{ inputs.dependencies != '' }} &&
+          (github.event_name == 'push' && steps.version_check.outputs.is_snapshot_version == 'true') || 
+          (github.event_name == 'release' && steps.version_check.outputs.is_snapshot_version == 'false')
         run: |
           IFS=',' read -r -a dirs <<< "${{ inputs.dependencies }}"
           for dir in "${dirs[@]}"
@@ -91,6 +89,9 @@ jobs:
           done
 
       - name: Publish package
+        if: |
+          (github.event_name == 'push' && steps.version_check.outputs.is_snapshot_version == 'true') || 
+          (github.event_name == 'release' && steps.version_check.outputs.is_snapshot_version == 'false')
         run: |
           cd ${{ inputs.path_to_package }}
           mvn --batch-mode deploy

--- a/.github/workflows/reusable-npm.yml
+++ b/.github/workflows/reusable-npm.yml
@@ -10,6 +10,9 @@ on:
       npm-token:
         required: true
 
+env:
+  VERSION: 0.11.0-next
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,13 +35,19 @@ jobs:
       - name: Build package
         run: npm run build -w ${{ inputs.package_workspace }}
 
-  check-version:
+  publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    outputs:
-      is_next_version: ${{ steps.version_check.outputs.is_next_version }}
+    if: github.event_name == 'push' || github.event_name == 'release'
+    defaults:
+      run:
+        working-directory: ./node
     steps:
-      - id: version_check
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Check version (only for push events)
+        if: github.event_name == 'push'
+        id: version_check
         run: |
           if [[ $VERSION == *"-next" ]]; then
             echo "is_next_version=true" >> $GITHUB_OUTPUT
@@ -46,19 +55,8 @@ jobs:
             echo "is_next_version=false" >> $GITHUB_OUTPUT
           fi
 
-  publish-next:
-    runs-on: ubuntu-latest
-    needs: check-version
-    if: github.event_name == 'push' && needs.check-version.outputs.is_next_version == 'true'
-    defaults:
-      run:
-        working-directory: ./node
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
         with:
           node-version: "20.10.0"
           registry-url: "https://registry.npmjs.org"
@@ -67,30 +65,13 @@ jobs:
         run: npm ci
 
       - name: Publish next version
+        if: github.event_name == 'push' && steps.version_check.outputs.is_next_version == 'true'
         run: npm run publish:next -w ${{ inputs.package_workspace }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
 
-  publish-latest:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
-    defaults:
-      run:
-        working-directory: ./node
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "20.10.0"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Publish new version and latest
+      - name: Publish latest version
+        if: github.event_name == 'release'
         run: npm run publish:latest -w ${{ inputs.package_workspace }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}


### PR DESCRIPTION
Prefix each name with the type (MAVEN, DOCKER, NPM). 
Use short names for each component.
Remove the long name for workflow calls, simply call them `run`. 
Merge jobs together to narrow down the amount of jobs being called.

Screenshot:
![image](https://github.com/eclipsesource/theia-cloud/assets/51790726/ba3749cd-5a0f-494f-ad55-7a6367bf9252)
