### PR TITLE
NPM workflow update and docker, maven workflow fix

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -55,6 +55,7 @@ jobs:
             echo "is_next_version=true" >> $GITHUB_OUTPUT
           else
             echo "is_next_version=false" >> $GITHUB_OUTPUT
+          fi
 
       # Create tags according to the state to be published:
       # - next version on main merge: create `*-next` and `*-next.<git_sha>` tags
@@ -70,6 +71,7 @@ jobs:
             echo "version_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}" >> $GITHUB_OUTPUT
             echo "next_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:${{ env.VERSION }}-next" >> $GITHUB_OUTPUT
             echo "latest_tag=${{ inputs.docker_org }}/${{ inputs.docker_image }}:latest" >> $GITHUB_OUTPUT
+          fi
 
       # Only build when we will publish, so either a main merge with next-version or a release
       - name: Build Docker image

--- a/.github/workflows/reusable-maven.yml
+++ b/.github/workflows/reusable-maven.yml
@@ -61,6 +61,7 @@ jobs:
             echo "is_snapshot_version=true" >> $GITHUB_OUTPUT
           else
             echo "is_snapshot_version=false" >> $GITHUB_OUTPUT
+          fi
 
       # Only continue from here when the version matches the event, so either:
       # - main merge with snapshot version

--- a/.github/workflows/reusable-npm.yml
+++ b/.github/workflows/reusable-npm.yml
@@ -10,8 +10,9 @@ on:
       npm-token:
         required: true
 
-env:
-  VERSION: 0.11.0-next
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build:
@@ -25,9 +26,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "20.10.0"
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci
@@ -49,6 +50,8 @@ jobs:
         if: github.event_name == 'push'
         id: version_check
         run: |
+          VERSION=$(node --print "require('./package.json').version")
+          echo "Package version: ${VERSION}"
           if [[ $VERSION == *"-next" ]]; then
             echo "is_next_version=true" >> $GITHUB_OUTPUT
           else
@@ -56,9 +59,9 @@ jobs:
           fi
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "20.10.0"
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -69,9 +72,11 @@ jobs:
         run: npm run publish:next -w ${{ inputs.package_workspace }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Publish latest version
         if: github.event_name == 'release'
         run: npm run publish:latest -w ${{ inputs.package_workspace }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Improve the reusable npm workflow:
- Configure npm provenance for package publishing
- Update setup-node action to v4
- Relax node version to any Node 20 version. Our docker images behave the same.
- Explicitly set permissions for workflow
- Get package version from package.json instead of hardcoded env variable

Fix reusable docker and maven workflows: Add missing `fi`s