### PR TITLE
node: Stabilize next version calculation for common and monitor-theia

### DIFF
--- a/node/common/package.json
+++ b/node/common/package.json
@@ -47,7 +47,7 @@
     "build:cjs": "tsc",
     "build:esm": "tsc -p tsconfig.esm.json",
     "prepublishOnly": "npm run build",
-    "publish:next": "npm pkg set version=`npm pkg get version | head -1  | tr -d '\"'`.`git rev-parse --short HEAD` && npm publish --tag next",
+    "publish:next": "npm pkg set version=`node --print \"require('./package.json').version\"`.`git rev-parse --short HEAD` && npm publish --tag next",
     "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {

--- a/node/monitor-theia/package.json
+++ b/node/monitor-theia/package.json
@@ -22,7 +22,7 @@
     "watch": "tsc -w",
     "lint": "eslint -c ../.eslintrc.js --ext .ts ./src",
     "prepublishOnly": "npm run build",
-    "publish:next": "npm pkg set version=`npm pkg get version | head -1  | tr -d '\"'`.`git rev-parse --short HEAD` && npm publish --tag next",
+    "publish:next": "npm pkg set version=`node --print \"require('./package.json').version\"`.`git rev-parse --short HEAD`",
     "publish:latest": "npm publish --tag latest"
   },
   "theiaExtensions": [


### PR DESCRIPTION
Before, the next version calculation used `npm pkg get version`. It turned out that its output is instable and even changes across minor node version upgrades.

This uses an inline node script (like the reusable workflow) to directly extract the version from the package.json.

---

I tested the next version calculation by removing the actual publish from the publish:next command and then executing it locally. This updated the version in the package.json as expected for me.