### PR TITLE
Rework Kubernetes resource naming and set up common unit tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
   "[java]": {
     "editor.detectIndentation": false,
     "editor.insertSpaces": true,
-    "editor.defaultFormatter": "redhat.java"
+    "editor.defaultFormatter": "redhat.java",
+    "editor.tabSize": 4
   },
   "[dockerfile]": {
     "editor.defaultFormatter": "ms-azuretools.vscode-docker"

--- a/java/common/org.eclipse.theia.cloud.common/pom.xml
+++ b/java/common/org.eclipse.theia.cloud.common/pom.xml
@@ -31,6 +31,13 @@
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -41,6 +48,18 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
@@ -146,8 +146,8 @@ public final class NamingUtil {
          * This must be shorter than {@link NamingUtil.VALID_NAME_LIMIT} We fill remaining space with additional
          * information about the workspace. This may be trimmed away however.
          */
-        return createName("workspace", identifier, workspace.getSpec().getUser(),
-                workspace.getSpec().getAppDefinition(), workspace.getMetadata().getUid());
+        return createName("ws", identifier, workspace.getSpec().getUser(), workspace.getSpec().getAppDefinition(),
+                workspace.getMetadata().getUid());
     }
 
     /**

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/NamingUtil.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2022 EclipseSource and others.
+ * Copyright (C) 2022-2024 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,7 +15,9 @@
  ********************************************************************************/
 package org.eclipse.theia.cloud.common.util;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.eclipse.theia.cloud.common.k8s.resource.appdefinition.AppDefinition;
 import org.eclipse.theia.cloud.common.k8s.resource.session.Session;
@@ -24,8 +26,6 @@ import org.eclipse.theia.cloud.common.k8s.resource.workspace.Workspace;
 public final class NamingUtil {
 
     public static final int VALID_NAME_LIMIT = 62;
-
-    private static final int MAX_IDENTIFIER_LENGTH = 24;
 
     public static final char VALID_NAME_PREFIX = 'a';
 
@@ -38,60 +38,105 @@ public final class NamingUtil {
     }
 
     /**
-     * Creates a string that can be used as a name for a kubernetes object. When the same arguments are passed to this
+     * @see NamingUtil#createName(AppDefinition, int, String)
+     */
+    public static String createName(AppDefinition appDefinition, int instance) {
+        return createName(appDefinition, instance);
+    }
+
+    /**
+     * Creates a string that can be used as a name for a Kubernetes object. When the same arguments are passed to this
      * method again, the resulting name will be the same. For different arguments the resulting name will be unique in
      * the cluster.
+     * <p>
+     * Typically, giving an <code>identifier</code> is not necessary because the Kubernetes object type (e.g.
+     * Deployment, ConfigMap, ...) already contains this information and names only need to be unique for the same
+     * object type. In turn, it is usually desired to have the same name for objects of different types that belong
+     * together (e.g. deployment and service). An <code>identifier</code> is useful if there are multiple objects of the
+     * same type for an AppDefinition.
+     * </p>
+     * <p>
+     * The created name contains a "session" prefix, the session's user and app definition, the identifier (if given),
+     * and the last segment of the Session's UID. User, app definition and identifier are shortened to keep the name
+     * within Kubernetes' character limit (63) minus 6 characters. The latter allows Kubernetes to add 6 characters at
+     * the end of deployment pod names while the pod names pod names will still contain the whole name of the deployment
+     * </p>
      * 
      * @param appDefinition the {@link AppDefinition}
      * @param instance      instance id
-     * @param identifier    a short description/name of the kubernetes object for which this name will be used. This
-     *                      will be part of the unique sections of the generated name. <b>The combined length of the
-     *                      instance and the identifier must be at most 23 characters long!</b>
+     * @param identifier    an optional short description/name of the Kubernetes object for which this name will be
+     *                      used. <b>This will be shortened to the first 11 characters</b>. May be <code>null</code>.
      * @return the name
      */
     public static String createName(AppDefinition appDefinition, int instance, String identifier) {
-        /*
-         * Kubenertes UIDs are standardized UUIDs/GUIDs. This means the uid string will have a length of 36. Unique part
-         * of the name will consist of the instance followed by the app definition's uuid followed by the identifier.
-         * Parts will be separated with "-". This must be shorter than {@link NamingUtil.VALID_NAME_LIMIT} We fill
-         * remaining space with additional information about the app definition. This may be trimmed away however.
-         */
-        String prefix = instance + "-";
-        return createName(prefix + appDefinition.getMetadata().getUid(), identifier,
-                getAdditionalInformation(appDefinition), MAX_IDENTIFIER_LENGTH - prefix.length());
+        String prefix = "instance-" + instance;
+        return createName(prefix, identifier, null, appDefinition.getSpec().getName(),
+                appDefinition.getMetadata().getUid());
     }
 
     /**
-     * Creates a string that can be used as a name for a kubernetes object. When the same arguments are passed to this
+     * @see NamingUtil#createName(Session, String)
+     */
+    public static String createName(Session session) {
+        return createName("session", null, session.getSpec().getUser(), session.getSpec().getAppDefinition(),
+                session.getMetadata().getUid());
+    }
+
+    /**
+     * Creates a string that can be used as a name for a Kubernetes object. When the same arguments are passed to this
      * method again, the resulting name will be the same. For different arguments the resulting name will be unique in
      * the cluster.
+     * <p>
+     * Typically, giving an <code>identifier</code> is not necessary because the Kubernetes object type (e.g.
+     * Deployment, ConfigMap, ...) already contains this information and names only need to be unique for the same
+     * object type. In turn, it is usually desired to have the same name for objects of different types that belong
+     * together (e.g. deployment and service). An <code>identifier</code> is useful if there are multiple objects of the
+     * same type for a Session.
+     * </p>
+     * <p>
+     * The created name contains a "session" prefix, the session's user and app definition, the identifier (if given),
+     * and the last segment of the Session's UID. User, app definition and identifier are shortened to keep the name
+     * within Kubernetes' character limit (63) minus 6 characters. The latter allows Kubernetes to add 6 characters at
+     * the end of deployment pod names while the pod names pod names will still contain the whole name of the deployment
+     * </p>
      * 
      * @param session    the {@link Session}
-     * @param identifier a short description/name of the kubernetes object for which this name will be used. This will
-     *                   be part of the unique sections of the generated name. <b>Must be at most 24 characters
-     *                   long!</b>
+     * @param identifier an optional short description/name of the Kubernetes object for which this name will be used.
+     *                   <b>This will be shortened to the first 11 characters</b>. May be <code>null</code>.
      * @return the name
      */
     public static String createName(Session session, String identifier) {
-        /*
-         * Kubenertes UIDs are standardized UUIDs/GUIDs. This means the uid string will have a length of 36. Unique part
-         * of the name will consist of the sessions's uuid followed by the identifier. Parts will be separated with "-".
-         * This must be shorter than {@link NamingUtil.VALID_NAME_LIMIT} We fill remaining space with additional
-         * information about the session. This may be trimmed away however.
-         */
-        return createName(session.getMetadata().getUid(), identifier, getAdditionalInformation(session),
-                MAX_IDENTIFIER_LENGTH);
+        return createName("session", identifier, session.getSpec().getUser(), session.getSpec().getAppDefinition(),
+                session.getMetadata().getUid());
     }
 
     /**
-     * Creates a string that can be used as a name for a kubernetes object. When the same arguments are passed to this
+     * @see NamingUtil#createName(Workspace, String)
+     */
+    public static String createName(Workspace workspace) {
+        return createName(workspace, null);
+    }
+
+    /**
+     * Creates a string that can be used as a name for a Kubernetes object. When the same arguments are passed to this
      * method again, the resulting name will be the same. For different arguments the resulting name will be unique in
      * the cluster.
+     * <p>
+     * Typically, giving an <code>identifier</code> is not necessary because the Kubernetes object type (e.g.
+     * Deployment, ConfigMap, ...) already contains this information and names only need to be unique for the same
+     * object type. In turn, it is usually desired to have the same name for objects of different types that belong
+     * together (e.g. deployment and service). An <code>identifier</code> is useful if there are multiple objects of the
+     * same type for a Workspace.
+     * </p>
+     * <p>
+     * The created name contains a "workspace" prefix, the workspace's user and app definition, the identifier (if
+     * given), and the last segment of the Workspace's UID. User, app definition and identifier are shortened to keep
+     * the name within Kubernetes' character limit (63).
+     * </p>
      * 
      * @param workspace  the {@link Workspace}
-     * @param identifier a short description/name of the kubernetes object for which this name will be used. This will
-     *                   be part of the unique sections of the generated name. <b>Must be at most 24 characters
-     *                   long!</b>
+     * @param identifier an optional short description/name of the Kubernetes object for which this name will be used.
+     *                   <b>This will be shortened to the first 11 characters</b>. May be <code>null</code>.
      * @return the name
      */
     public static String createName(Workspace workspace, String identifier) {
@@ -101,43 +146,77 @@ public final class NamingUtil {
          * This must be shorter than {@link NamingUtil.VALID_NAME_LIMIT} We fill remaining space with additional
          * information about the workspace. This may be trimmed away however.
          */
-        return createName(workspace.getMetadata().getUid(), identifier, getAdditionalInformation(workspace),
-                MAX_IDENTIFIER_LENGTH);
+        return createName("workspace", identifier, workspace.getSpec().getUser(),
+                workspace.getSpec().getAppDefinition(), workspace.getMetadata().getUid());
     }
 
     /**
-     * Joins prefix, identifier, and additionalInformation with "-" and enforces conventions to get a valid kubernetes
-     * name.
+     * Builds a valid Kubernetes object names. Except for the prefix, all segments are limited to a fixed number of
+     * characters to ensure that the resulting name includes information from all parameters.
      * 
-     * @param prefix
-     * @param identifier
-     * @param additionalInformation
-     * @param maxIdentifierLength   max length of the identifier
-     * @return the name
-     * @throw {@link IllegalArgumentException} in case the passed identifier is too long
+     * @param prefix        The prefix to start the object name with. Should start with a letter and be at most 13
+     *                      characters long. Longer prefixes are possible but might lead to other info being cut short.
+     * @param identifier    an optional short description/name of the kubernetes object for which this name will be
+     *                      used. <b>This will be shortened to the first 11 characters</b>. May be <code>null</code>.
+     * @param user          The user, may be <code>null</code>
+     * @param appDefinition The app definition name, may be <code>null</code>
+     * @param uid           a unique Kubernetes object id that the name relates to. I.e. the UID of a session when
+     *                      creating the name of a session deployment.
+     * @return the joined and valid Kubernetes name
      */
-    private static String createName(String prefix, String identifier, String additionalInformation,
-            int maxIdentifierLength) {
-        if (identifier.length() > maxIdentifierLength) {
-            throw new IllegalArgumentException(
-                    "Identifier " + identifier + " is too long. Max length is " + maxIdentifierLength);
+    private static String createName(String prefix, String identifier, String user, String appDefinition, String uid) {
+        /*
+         * Kubenertes UIDs are standardized UUIDs/GUIDs. This means the uid string will have a length of 36. We take the
+         * last segment with length 12 to generate unique names for each Session even if user and app definition are the
+         * same.
+         */
+        String shortUid = trimUid(uid);
+
+        // If the user is an email address, only take the part before the @ sign because
+        // this is usually sufficient to identify the user.
+        String userName = user.split("@")[0];
+
+        int infoSegmentLength;
+        String shortenedIdentifier = null;
+        if (identifier == null || identifier.isBlank()) {
+            infoSegmentLength = 17;
+        } else {
+            infoSegmentLength = 11;
+            shortenedIdentifier = trimLength(identifier, infoSegmentLength);
         }
-        return asValidName(String.join("-", prefix, identifier, additionalInformation));
+        String shortUserName = trimLength(userName, infoSegmentLength);
+        String shortAppDef = trimLength(appDefinition, infoSegmentLength);
+
+        return asValidName(prefix, shortenedIdentifier, shortUserName, shortAppDef, shortUid);
     }
 
-    private static String getAdditionalInformation(AppDefinition appDefinition) {
-        return appDefinition.getSpec().getName();
+    /**
+     * Kubenertes UIDs are standardized UUIDs/GUIDs. This means the uid string will have a length of 36. We take the
+     * last segment with length 12 to generate unique names for Kubernetes objects even if other user and app definition
+     * are the same.
+     */
+    private static String trimUid(String uid) {
+        return uid.substring(uid.length() - 12, uid.length());
     }
 
-    private static String getAdditionalInformation(Session session) {
-        String workspace = (session.getSpec().getWorkspace() == null || session.getSpec().getWorkspace().isBlank())
-                ? "none"
-                : session.getSpec().getWorkspace();
-        return session.getSpec().getUser() + "-" + workspace + "-" + session.getSpec().getAppDefinition();
+    private static String trimLength(String text, int maxLength) {
+        if (text == null) {
+            return text;
+        }
+        return text.substring(0, Math.min(text.length(), maxLength));
     }
 
-    private static String getAdditionalInformation(Workspace workspace) {
-        return workspace.getSpec().getName();
+    /**
+     * Joins the given name segments with "-" and enforces conventions to get a valid kubernetes name. Empty or null
+     * segments are removed before joining them.
+     * 
+     * @param segments String segments to join. Segments may be null or empty. These are removed before joining.
+     * @return the name
+     */
+    private static String asValidName(String... segments) {
+        String[] filteredSegments = Arrays.stream(segments).filter(Objects::nonNull).filter(s -> !s.isBlank())
+                .toArray(String[]::new);
+        return asValidName(String.join("-", filteredSegments));
     }
 
     /**

--- a/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/WorkspaceUtil.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/main/java/org/eclipse/theia/cloud/common/util/WorkspaceUtil.java
@@ -23,7 +23,6 @@ import org.eclipse.theia.cloud.common.k8s.resource.workspace.Workspace;
 
 public final class WorkspaceUtil {
     private static final String SESSION_SUFFIX = "-session";
-    private static final String STORAGE_SUFFIX = "pvc";
     private static final String WORKSPACE_PREFIX = "ws-";
     private static final int WORKSPACE_NAME_LIMIT = NamingUtil.VALID_NAME_LIMIT - SESSION_SUFFIX.length();
 
@@ -52,7 +51,7 @@ public final class WorkspaceUtil {
     }
 
     public static String getStorageName(Workspace workspace) {
-        return NamingUtil.createName(workspace, STORAGE_SUFFIX);
+        return NamingUtil.createName(workspace);
     }
 
     public static String generateWorkspaceLabel(String user, String appDefinitionName) {

--- a/java/common/org.eclipse.theia.cloud.common/src/test/java/org/eclipse/theia/cloud/common/util/NamingUtilTests.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/test/java/org/eclipse/theia/cloud/common/util/NamingUtilTests.java
@@ -1,0 +1,119 @@
+/********************************************************************************
+ * Copyright (C) 2024 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+package org.eclipse.theia.cloud.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.theia.cloud.common.k8s.resource.session.Session;
+import org.eclipse.theia.cloud.common.k8s.resource.session.SessionSpec;
+import org.eclipse.theia.cloud.common.k8s.resource.workspace.Workspace;
+import org.eclipse.theia.cloud.common.k8s.resource.workspace.WorkspaceSpec;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+/**
+ * Unit tests for {@link NamingUtil}.
+ *
+ */
+class NamingUtilTests {
+
+    @Test
+    void createName_SessionAndNullIdentifier() {
+	Session session = createSession();
+
+	String result = NamingUtil.createName(session, null);
+	assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
+    }
+
+    @Test
+    void createName_SessionAndWhitespaceIdentifier() {
+	Session session = createSession();
+
+	String result = NamingUtil.createName(session, " ");
+	assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
+    }
+
+    @Test
+    void createName_SessionAndEmptyIdentifier() {
+	Session session = createSession();
+
+	String result = NamingUtil.createName(session, "");
+	assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
+    }
+
+    @Test
+    void createName_SessionAndIdentifier() {
+	Session session = createSession();
+
+	String result = NamingUtil.createName(session, "longidentifier");
+	assertEquals("session-longidentif-some-userna-test-app-de-426930ea37d7", result);
+    }
+
+    @Test
+    void createName_WorkspaceAndNullIdentifier() {
+	Workspace workspace = createWorkspace();
+
+	String result = NamingUtil.createName(workspace, null);
+	assertEquals("workspace-some-username-test-app-definiti-381261d79c23", result);
+    }
+
+    @Test
+    void createName_WorkspaceAndWhitespaceIdentifier() {
+	Workspace workspace = createWorkspace();
+
+	String result = NamingUtil.createName(workspace, " ");
+	assertEquals("workspace-some-username-test-app-definiti-381261d79c23", result);
+    }
+
+    @Test
+    void createName_WorkspaceAndEmptyIdentifier() {
+	Workspace workspace = createWorkspace();
+
+	String result = NamingUtil.createName(workspace, "");
+	assertEquals("workspace-some-username-test-app-definiti-381261d79c23", result);
+    }
+
+    @Test
+    void createName_WorkspaceAndIdentifier() {
+	Workspace workspace = createWorkspace();
+
+	String result = NamingUtil.createName(workspace, "longidentifier");
+	assertEquals("workspace-longidentif-some-userna-test-app-de-381261d79c23", result);
+    }
+
+    private Session createSession() {
+	Session session = new Session();
+	ObjectMeta objectMeta = new ObjectMeta();
+	objectMeta.setUid("2b8a76db-a049-496f-b897-426930ea37d7");
+	session.setMetadata(objectMeta);
+	SessionSpec sessionSpec = new SessionSpec("some-session-spec", "test-app-definition",
+		"some.username@example.org");
+	session.setSpec(sessionSpec);
+	return session;
+    }
+
+    private Workspace createWorkspace() {
+	Workspace workspace = new Workspace();
+	ObjectMeta objectMeta = new ObjectMeta();
+	objectMeta.setUid("6f1a8966-4d5a-41dc-82ba-381261d79c23");
+	workspace.setMetadata(objectMeta);
+	WorkspaceSpec workspaceSpec = new WorkspaceSpec("some-workspace-spec", "some-workspace-label",
+		"test-app-definition", "some.username@example.org");
+	workspace.setSpec(workspaceSpec);
+	return workspace;
+    }
+}

--- a/java/common/org.eclipse.theia.cloud.common/src/test/java/org/eclipse/theia/cloud/common/util/NamingUtilTests.java
+++ b/java/common/org.eclipse.theia.cloud.common/src/test/java/org/eclipse/theia/cloud/common/util/NamingUtilTests.java
@@ -27,93 +27,92 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 
 /**
  * Unit tests for {@link NamingUtil}.
- *
  */
 class NamingUtilTests {
 
     @Test
     void createName_SessionAndNullIdentifier() {
-	Session session = createSession();
+        Session session = createSession();
 
-	String result = NamingUtil.createName(session, null);
-	assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
+        String result = NamingUtil.createName(session, null);
+        assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
     }
 
     @Test
     void createName_SessionAndWhitespaceIdentifier() {
-	Session session = createSession();
+        Session session = createSession();
 
-	String result = NamingUtil.createName(session, " ");
-	assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
+        String result = NamingUtil.createName(session, " ");
+        assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
     }
 
     @Test
     void createName_SessionAndEmptyIdentifier() {
-	Session session = createSession();
+        Session session = createSession();
 
-	String result = NamingUtil.createName(session, "");
-	assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
+        String result = NamingUtil.createName(session, "");
+        assertEquals("session-some-username-test-app-definiti-426930ea37d7", result);
     }
 
     @Test
     void createName_SessionAndIdentifier() {
-	Session session = createSession();
+        Session session = createSession();
 
-	String result = NamingUtil.createName(session, "longidentifier");
-	assertEquals("session-longidentif-some-userna-test-app-de-426930ea37d7", result);
+        String result = NamingUtil.createName(session, "longidentifier");
+        assertEquals("session-longidentif-some-userna-test-app-de-426930ea37d7", result);
     }
 
     @Test
     void createName_WorkspaceAndNullIdentifier() {
-	Workspace workspace = createWorkspace();
+        Workspace workspace = createWorkspace();
 
-	String result = NamingUtil.createName(workspace, null);
-	assertEquals("workspace-some-username-test-app-definiti-381261d79c23", result);
+        String result = NamingUtil.createName(workspace, null);
+        assertEquals("ws-some-username-test-app-definiti-381261d79c23", result);
     }
 
     @Test
     void createName_WorkspaceAndWhitespaceIdentifier() {
-	Workspace workspace = createWorkspace();
+        Workspace workspace = createWorkspace();
 
-	String result = NamingUtil.createName(workspace, " ");
-	assertEquals("workspace-some-username-test-app-definiti-381261d79c23", result);
+        String result = NamingUtil.createName(workspace, " ");
+        assertEquals("ws-some-username-test-app-definiti-381261d79c23", result);
     }
 
     @Test
     void createName_WorkspaceAndEmptyIdentifier() {
-	Workspace workspace = createWorkspace();
+        Workspace workspace = createWorkspace();
 
-	String result = NamingUtil.createName(workspace, "");
-	assertEquals("workspace-some-username-test-app-definiti-381261d79c23", result);
+        String result = NamingUtil.createName(workspace, "");
+        assertEquals("ws-some-username-test-app-definiti-381261d79c23", result);
     }
 
     @Test
     void createName_WorkspaceAndIdentifier() {
-	Workspace workspace = createWorkspace();
+        Workspace workspace = createWorkspace();
 
-	String result = NamingUtil.createName(workspace, "longidentifier");
-	assertEquals("workspace-longidentif-some-userna-test-app-de-381261d79c23", result);
+        String result = NamingUtil.createName(workspace, "longidentifier");
+        assertEquals("ws-longidentif-some-userna-test-app-de-381261d79c23", result);
     }
 
     private Session createSession() {
-	Session session = new Session();
-	ObjectMeta objectMeta = new ObjectMeta();
-	objectMeta.setUid("2b8a76db-a049-496f-b897-426930ea37d7");
-	session.setMetadata(objectMeta);
-	SessionSpec sessionSpec = new SessionSpec("some-session-spec", "test-app-definition",
-		"some.username@example.org");
-	session.setSpec(sessionSpec);
-	return session;
+        Session session = new Session();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setUid("2b8a76db-a049-496f-b897-426930ea37d7");
+        session.setMetadata(objectMeta);
+        SessionSpec sessionSpec = new SessionSpec("some-session-spec", "test-app-definition",
+                "some.username@example.org");
+        session.setSpec(sessionSpec);
+        return session;
     }
 
     private Workspace createWorkspace() {
-	Workspace workspace = new Workspace();
-	ObjectMeta objectMeta = new ObjectMeta();
-	objectMeta.setUid("6f1a8966-4d5a-41dc-82ba-381261d79c23");
-	workspace.setMetadata(objectMeta);
-	WorkspaceSpec workspaceSpec = new WorkspaceSpec("some-workspace-spec", "some-workspace-label",
-		"test-app-definition", "some.username@example.org");
-	workspace.setSpec(workspaceSpec);
-	return workspace;
+        Workspace workspace = new Workspace();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setUid("6f1a8966-4d5a-41dc-82ba-381261d79c23");
+        workspace.setMetadata(objectMeta);
+        WorkspaceSpec workspaceSpec = new WorkspaceSpec("some-workspace-spec", "some-workspace-label",
+                "test-app-definition", "some.username@example.org");
+        workspace.setSpec(workspaceSpec);
+        return workspace;
     }
 }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudConfigMapUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudConfigMapUtil.java
@@ -35,8 +35,8 @@ public final class TheiaCloudConfigMapUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(TheiaCloudConfigMapUtil.class);
 
-    public static final String CONFIGMAP_PROXY_NAME = "config";
-    public static final String CONFIGMAP_EMAIL_NAME = "emailconfig";
+    public static final String CONFIGMAP_PROXY_NAME = "proxy";
+    public static final String CONFIGMAP_EMAIL_NAME = "email";
 
     private TheiaCloudConfigMapUtil() {
     }

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudDeploymentUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudDeploymentUtil.java
@@ -55,11 +55,11 @@ public final class TheiaCloudDeploymentUtil {
     }
 
     public static String getDeploymentName(AppDefinition appDefinition, int instance) {
-        return NamingUtil.createName(appDefinition, instance, DEPLOYMENT_NAME);
+        return NamingUtil.createName(appDefinition, instance);
     }
 
     public static String getDeploymentName(Session session) {
-        return NamingUtil.createName(session, DEPLOYMENT_NAME);
+        return NamingUtil.createName(session);
     }
 
     public static Integer getId(String correlationId, AppDefinition appDefinition, Deployment deployment) {

--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudServiceUtil.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/util/TheiaCloudServiceUtil.java
@@ -46,11 +46,11 @@ public final class TheiaCloudServiceUtil {
     }
 
     public static String getServiceName(AppDefinition appDefinition, int instance) {
-        return NamingUtil.createName(appDefinition, instance, SERVICE_NAME);
+        return NamingUtil.createName(appDefinition, instance);
     }
 
     public static String getServiceName(Session session) {
-        return NamingUtil.createName(session, SERVICE_NAME);
+        return NamingUtil.createName(session);
     }
 
     public static Integer getId(String correlationId, AppDefinition appDefinition, Service service) {


### PR DESCRIPTION
Fixes #324 

Note: This will need a rebase if the formatting PR #325  is merged first. Otherwise, the touched Java files need to be formatted in the PR, too.

Rework the naming of Kubernetes resources for workspaces and sessions in the common package used by operator and service.

The goal is to make resource names more readable and contain useful information. Resource names now contain a prefix, optional identifier, user, app definition and the last segment of the source CRs (session, workspace, app definition) UID.

Also configure unit tests using JUnit 5 for the common maven module and add some tests for the new name generation.

---

Notes:
- Most suffixes and prefixes containing the resource type were removed because this is already given by the type.
- The new name calculation limits names to length 57 to leave 6 characters for Kubernetes to append a hash to deployment pods. This is at least 5 characters plus a dash. If there is not enough space in the resource name, the end of the pod name is replaced with this. Thus, the limit of 57 characters to avoid this.
- Changed the identifiers for the email and proxy config maps to `email` resp. `proxy` to be as short and concise as possible.


---

See an example of created resources for a user `bar` with app definition `theia-cloud-demo`:
![image](https://github.com/user-attachments/assets/08fe63d4-f68e-441e-88af-05dc65352de7)
