### PR TITLE
Check Workspace Owner when launching non-ephemeral Sessions

### DIFF
--- a/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
+++ b/java/operator/org.eclipse.theia.cloud.operator/src/main/java/org/eclipse/theia/cloud/operator/handler/session/LazySessionHandler.java
@@ -348,6 +348,15 @@ public class LazySessionHandler implements SessionHandler {
             return Optional.empty();
 
         }
+        if (!session.getSpec().getUser().equals(workspace.get().getSpec().getUser())) {
+            // the workspace is owned by a different user. do not mount and go ephemeral
+            // should get prevented by service, but we need to be sure to not expose data
+            LOGGER.error(formatLogMessage(correlationId,
+                    "Workspace is owned by " + workspace.get().getSpec().getUser() + ", but requesting user is "
+                            + session.getSpec().getUser()));
+            return Optional.empty();
+        }
+
         String storageName = WorkspaceUtil.getStorageName(workspace.get());
         if (!client.persistentVolumeClaimsClient().has(storageName)) {
             LOGGER.info(formatLogMessage(correlationId,


### PR DESCRIPTION
The Service does filter out workspaces if the user does not match via https://github.com/eclipsesource/theia-cloud/blob/37785cfeb9a8b4cebd79e404750b74c2d8ec30a1/java/service/org.eclipse.theia.cloud.service/src/main/java/org/eclipse/theia/cloud/service/K8sUtil.java#L127

This change just makes sure that if there was a bug in the service, the operator does not just expose the workspace belonging to a different user. 