### PR TITLE
Fix maven publishing for release versions

### DIFF
--- a/.github/workflows/reusable-maven.yml
+++ b/.github/workflows/reusable-maven.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - id: version_check
+      - name: Run Version Check
+        id: version_check
         run: |
           cd ${{ inputs.path_to_package }}
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
@@ -77,9 +78,11 @@ jobs:
 
       - name: Build dependencies
         if: |
-          ${{ inputs.dependencies != '' }} &&
-          (github.event_name == 'push' && steps.version_check.outputs.is_snapshot_version == 'true') || 
-          (github.event_name == 'release' && steps.version_check.outputs.is_snapshot_version == 'false')
+          ${{ inputs.dependencies != '' }} && 
+          ( 
+            (github.event_name == 'push' && steps.version_check.outputs.is_snapshot_version == 'true') || 
+            (github.event_name == 'release' && steps.version_check.outputs.is_snapshot_version == 'false')
+          )
         run: |
           IFS=',' read -r -a dirs <<< "${{ inputs.dependencies }}"
           for dir in "${dirs[@]}"
@@ -105,7 +108,7 @@ jobs:
           (github.event_name == 'release' && steps.version_check.outputs.is_snapshot_version == 'false')
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          credentials_json: "${{ secrets.GCP_SA_KEY }}"
 
       - name: Publish package to Google Artifact Registry
         if: |

--- a/java/common/maven-conf/pom.xml
+++ b/java/common/maven-conf/pom.xml
@@ -45,6 +45,11 @@
         <profile>
             <id>artifact-registry</id>
             <distributionManagement>
+                <repository>
+                    <id>artifact-registry</id>
+                    <name>Google Artifact Registry</name>
+                    <url>artifactregistry://europe-west3-maven.pkg.dev/kubernetes-238012/theia-cloud</url>
+                </repository>
                 <snapshotRepository>
                     <id>artifact-registry</id>
                     <name>Google Artifact Registry</name>


### PR DESCRIPTION
Add the repository field to the pom.xml.
Also try to fix that the build dependencies step is not executed on release version pushes.

_Note: I manually pushed the 0.11.0 versions of the maven artifacts to the Google Artifact Registry._